### PR TITLE
Add initial dex setup into ecosystem chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ where `<release-name>` is the name that you gave the ecosystem during installati
 
 Once the `helm test` command ends and displays a success message, the Ecosystem has been set up correctly and is ready to be used.
 
+### Accessing services
+
 To determine the URL of the Ecosystem bootstrap, issue the command:
 
 ```console
@@ -121,14 +123,20 @@ Look for the `api-external` service and the NodePort associated with the 8080 po
 test-api-external  NodePort  10.107.160.208  <none>  9010:31359/TCP,9011:31422/TCP,8080:30960/TCP  18s
 ```
 
-If the external hostname you provided was `example.com`, the bootstrap URL will be `http://example.com:30960/boostrap`. You will enter this into the Eclipse plugin preferences, or in a galasactl command's `--bootstrap` option.
+If the external hostname you provided was `example.com`, the bootstrap URL will be `http://example.com:30960/bootstrap`. You will enter this into the Eclipse plugin preferences, or in a galasactl command's `--bootstrap` option.
+
+If you have enabled ingress and are deploying to minikube, add an entry to your `/etc/hosts` file like the one shown below, ensuring the IP address matches the output of `minikube ip`.
+
+```console
+192.168.49.2 example.com
+```
 
 ### Upgrading the Galasa Ecosystem
 
 If you want to upgrade the Galasa Ecosystem to use a newer version of Galasa, for example, then you can use the following command:
 
 ```console
-helm upgrade --reuse-values --set galasaVersion=0.25.0 --wait
+helm upgrade <release-name> galasa/ecosystem --reuse-values --set galasaVersion=0.28.0 --wait
 ```
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -14,7 +14,31 @@ It is highly discouraged to use minikube for production purposes since it only p
 
 If you would like to install the chart into minikube, ensure you have minikube [installed](https://minikube.sigs.k8s.io/docs/start/) and that it is running with `minikube status`. If minikube is not running, start it by running `minikube start`.
 
-Once minikube is running, follow the instructions in the sections below to install the Galasa Ecosystem chart. 
+Once minikube is running, follow the instructions in the sections below to install the Galasa Ecosystem chart.
+
+### Dex
+**Note: The ecosystem chart's use of Dex is still under development and is subject to change.**
+
+In a future release, [Dex](https://dexidp.io) will be used to authenticate users attempting to interact with a Galasa Ecosystem.
+
+To configure dex to authenticate through GitHub:
+
+1. Register an OAuth application in [GitHub](https://github.com/settings/applications/new), ensuring the application's callback URL is set to `http://<your-dex-issuer>/callback`
+2. Add a GitHub connector to your dex configuration (see the `dexConfig` value in the [values.yaml](./charts/ecosystem/values.yaml) file) as follows:
+    ```yaml
+    dexConfig:
+      connectors:
+      - type: github
+        id: github
+        name: GitHub
+        config:
+          clientID: $GITHUB_CLIENT_ID
+          clientSecret: $GITHUB_CLIENT_SECRET
+          redirectURI: http://<your-dex-issuer>/callback
+    ```
+    where `$GITHUB_CLIENT_ID` and `$GITHUB_CLIENT_SECRET` correspond to the registered OAuth application's client ID and secret.
+
+For more information on configuring dex, refer to the [Dex documentation](https://dexidp.io/docs).
 
 ### RBAC
 If RBAC is active on your Kubernetes cluster, you will need to get your Kubernetes administrator to replace the [placeholder username](https://github.com/galasa-dev/helm/blob/main/charts/ecosystem/rbac-admin.yaml#L39) in the [rbac-admin.yaml](./charts/ecosystem/rbac-admin.yaml) file with a username corresponding to a user with access to your cluster to assign them the `galasa-admin` role. This role allows assigned users to run the helm install/upgrade/delete commands to interact with the helm chart.

--- a/README.md
+++ b/README.md
@@ -72,11 +72,17 @@ Download the [values.yaml](charts/ecosystem/values.yaml) file and within it:
   2. Set the `externalHostname` value to the DNS hostname or IP address of the Kubernetes node that will be used to access the Galasa NodePort services.
      * If you are deploying to minikube, the cluster's IP address can be retrieved by running `minikube ip`.
 
+If you are deploying to minikube and are using Ingress to expose services, ensure the NGINX Ingress controller is enabled by running:
+
+```console
+minikube addons enable ingress
+```
+
 Having configured your [values.yaml](charts/ecosystem/values.yaml) file, use the following command to install the Galasa Ecosystem chart:
 
 ```console
-helm install -f /path/to/values.yaml <release-name> galasa/ecosystem --wait 
-``` 
+helm install -f /path/to/values.yaml <release-name> galasa/ecosystem --wait
+```
 
 where `/path/to/values.yaml` is the path to the `values.yaml` file that you downloaded, and `<release-name>` is the name that you want to give the ecosystem.
 
@@ -133,10 +139,16 @@ To install the latest development version of the Galasa Ecosystem chart, clone t
 3. Set the `externalHostname` value to the DNS hostname or IP address of the Kubernetes node that will be used to access the Galasa NodePort services.
    * If you are deploying to minikube, the cluster's IP address can be retrieved by running `minikube ip`.
 
+If you are deploying to minikube and are using Ingress to expose services, ensure the NGINX Ingress controller is enabled by running:
+
+```console
+minikube addons enable ingress
+```
+
 Next, run the following command, providing the path to the [`ecosystem`](./charts/ecosystem) directory in this repository (e.g. `~/helm/charts/ecosystem`).
 
 ```console
-helm install <release-name> /path/to/helm/charts/ecosystem --wait 
-``` 
+helm install <release-name> /path/to/helm/charts/ecosystem --wait
+```
 
 Once the `helm install` command ends with a successful deployment message, you can follow the installation instructions above to test the deployed ecosystem using `helm test` and determine the bootstrap URL.

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -6,4 +6,4 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-dex-config
 data:
-  config.yaml: {{ .Values.dexConfig | toYaml | quote }}
+  config.yaml: {{ .Values.dex.config | toYaml | quote }}

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -1,0 +1,9 @@
+#
+# Copyright contributors to the Galasa project 
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-dex-config
+data:
+  config.yaml: {{ .Values.dexConfig | toYaml | quote }}

--- a/charts/ecosystem/templates/dex-ingress.yaml
+++ b/charts/ecosystem/templates/dex-ingress.yaml
@@ -8,9 +8,9 @@ metadata:
   name: {{ .Release.Name }}-dex
   annotations:
     {{- with .Values.ingress.annotations }}
-      {{- toYaml .Values.ingress.annotations | indent 4 }}
+      {{- toYaml . | indent 4 }}
     {{- end }}
-    nginx.ingress.kubernetes.io/rewrite-target: /dex/$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   rules:
   - host: {{ .Values.ingress.host }}

--- a/charts/ecosystem/templates/dex-ingress.yaml
+++ b/charts/ecosystem/templates/dex-ingress.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright contributors to the Galasa project
+#
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-dex
+  annotations:
+    {{- with .Values.ingress.annotations }}
+      {{- toYaml .Values.ingress.annotations | indent 4 }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: /dex/$2
+spec:
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /dex(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-dex
+            port:
+              number: 5556
+{{- end }}

--- a/charts/ecosystem/templates/dex-ingress.yaml
+++ b/charts/ecosystem/templates/dex-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   rules:
-  - host: {{ .Values.ingress.host }}
+  - host: {{ .Values.externalHostname }}
     http:
       paths:
       - path: /dex(/|$)(.*)

--- a/charts/ecosystem/templates/dex-service-external.yaml
+++ b/charts/ecosystem/templates/dex-service-external.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright contributors to the Galasa project 
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-dex-external
+  labels:
+    app: {{ .Release.Name }}-dex-external
+spec:
+  type: NodePort
+  selector:
+    app: {{ .Release.Name }}-dex
+  ports:
+  - name: http
+    port: 5556
+    targetPort: 5556
+    protocol: TCP
+  - name: telemetry
+    port: 5558
+    targetPort: 5558
+    protocol: TCP

--- a/charts/ecosystem/templates/dex-service-external.yaml
+++ b/charts/ecosystem/templates/dex-service-external.yaml
@@ -15,6 +15,16 @@ spec:
   - name: http
     port: 5556
     targetPort: 5556
+    {{- if .Values.dex.nodePorts.http }}
+    nodePort: {{ .Values.dex.nodePorts.http }}
+    {{- end }}
+    protocol: TCP
+  - name: grpc
+    port: 5557
+    targetPort: 5557
+    {{- if .Values.dex.nodePorts.grpc }}
+    nodePort: {{ .Values.dex.nodePorts.grpc }}
+    {{- end }}
     protocol: TCP
   - name: telemetry
     port: 5558

--- a/charts/ecosystem/templates/dex-service-internal.yaml
+++ b/charts/ecosystem/templates/dex-service-internal.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright contributors to the Galasa project 
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-dex
+  labels:
+    app: {{ .Release.Name }}-dex
+spec:
+  ports:
+  - name: http
+    port: 5556
+  - name: telemetry
+    port: 5558
+  selector:
+    app: {{ .Release.Name }}-dex

--- a/charts/ecosystem/templates/dex-service-internal.yaml
+++ b/charts/ecosystem/templates/dex-service-internal.yaml
@@ -11,6 +11,8 @@ spec:
   ports:
   - name: http
     port: 5556
+  - name: grpc
+    port: 5557
   - name: telemetry
     port: 5558
   selector:

--- a/charts/ecosystem/templates/dex.yaml
+++ b/charts/ecosystem/templates/dex.yaml
@@ -27,6 +27,8 @@ spec:
           - serve
           - --web-http-addr
           - 0.0.0.0:5556
+          - --grpc-addr
+          - 0.0.0.0:5557
           - --telemetry-addr
           - 0.0.0.0:5558
           - /etc/dex/config.yaml
@@ -34,6 +36,9 @@ spec:
         ports:
         - name: http
           containerPort: 5556
+          protocol: TCP
+        - name: grpc
+          containerPort: 5557
           protocol: TCP
         - name: telemetry
           containerPort: 5558

--- a/charts/ecosystem/templates/dex.yaml
+++ b/charts/ecosystem/templates/dex.yaml
@@ -1,0 +1,62 @@
+#
+# Copyright contributors to the Galasa project 
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ .Release.Name }}-dex
+  name: {{ .Release.Name }}-dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-dex
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-dex
+
+    spec:
+      serviceAccountName: galasa
+      containers:
+      - image: {{ .Values.dexImage }}
+        name: dex
+        args:
+          - dex
+          - serve
+          - --web-http-addr
+          - 0.0.0.0:5556
+          - --telemetry-addr
+          - 0.0.0.0:5558
+          - /etc/dex/config.yaml
+
+        ports:
+        - name: http
+          containerPort: 5556
+          protocol: TCP
+        - name: telemetry
+          containerPort: 5558
+          protocol: TCP
+
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: telemetry
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: telemetry
+
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex
+          readOnly: true
+
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Release.Name }}-dex-config
+          items:
+          - key: config.yaml
+            path: config.yaml

--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -40,4 +40,34 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: galasa
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: galasa-dex
+rules:
+- apiGroups: ["dex.coreos.com"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["list", "create"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: galasa-dex
+roleRef:
+  kind: ClusterRole
+  name: galasa-dex
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: galasa
+
 {{- end }}

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -49,3 +49,36 @@ catalogDiskSize: "1Gi"
 #
 etcdImage: "quay.io/coreos/etcd:v3.2.25"
 couchdbImage: "couchdb:2.3.1"
+dexImage: "ghcr.io/dexidp/dex:v2.32.0"
+#
+#
+# Values to enable and configure the use of ingress
+#
+ingress:
+  # Enables/disables the use of ingress
+  enabled: true
+
+  # Annotations to be added to ingresses
+  annotations: {}
+
+  # The host to access services through
+  host: example.com
+#
+#
+# Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
+#
+dexConfig:
+    issuer: http://example.com/dex
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+    
+    # Default is set to use an example email and password.
+    enablePasswordDB: true
+    staticPasswords:
+    - email: "admin@example.com"
+      # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: "admin"
+      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -53,6 +53,7 @@ dexImage: "ghcr.io/dexidp/dex:v2.32.0"
 #
 #
 # Values to enable and configure the use of ingress
+# Note: The externalHostname value must be a valid DNS name for ingress to be used.
 #
 ingress:
   # Enables/disables the use of ingress
@@ -60,9 +61,6 @@ ingress:
 
   # Annotations to be added to ingresses
   annotations: {}
-
-  # The host to access services through - must not be an IP address.
-  host: example.com
 #
 #
 # Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -61,7 +61,7 @@ ingress:
   # Annotations to be added to ingresses
   annotations: {}
 
-  # The host to access services through
+  # The host to access services through - must not be an IP address.
   host: example.com
 #
 #

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -63,20 +63,34 @@ ingress:
   annotations: {}
 #
 #
-# Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
+# Values to configure the ecosystem's use of Dex
 #
-dexConfig:
-  issuer: http://example.com/dex
-  storage:
-    type: kubernetes
-    config:
-      inCluster: true
-  
-  # Default is set to use an example email and password.
-  enablePasswordDB: true
-  staticPasswords:
-  - email: "admin@example.com"
-    # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
-    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-    username: "admin"
-    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+dex:
+  # NodePorts to access Dex services through (Helm will dynamically assign NodePorts in the 
+  # 30000 to 32767 range if they are left blank).
+  nodePorts:
+    grpc: 32000
+    http: # blank - dynamically assigned
+
+  # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
+  config:
+    issuer: http://example.com/dex
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+
+    # Enable Dex's gRPC API for clients to interact with.
+    grpc:
+      # The address of the exposed gRPC API server. Must be a valid {HOST}:{PORT} combination.
+      addr: example.com:32000
+      reflection: true
+    
+    # Default is set to use an example email and password.
+    enablePasswordDB: true
+    staticPasswords:
+    - email: "admin@example.com"
+      # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: "admin"
+      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -66,17 +66,17 @@ ingress:
 # Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
 #
 dexConfig:
-    issuer: http://example.com/dex
-    storage:
-      type: kubernetes
-      config:
-        inCluster: true
-    
-    # Default is set to use an example email and password.
-    enablePasswordDB: true
-    staticPasswords:
-    - email: "admin@example.com"
-      # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
-      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-      username: "admin"
-      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+  issuer: http://example.com/dex
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+  
+  # Default is set to use an example email and password.
+  enablePasswordDB: true
+  staticPasswords:
+  - email: "admin@example.com"
+    # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1460

Changes:
- Installed dex in the ecosystem chart
- Added ingress and dex-related chart values
- Added a draft dex section to the README
- Enabled dex's gRPC API, which can be accessed through an assigned NodePort