### PR TITLE
Use etcd for Dex's backing store, remove ClusterRole and bindings

### DIFF
--- a/charts/ecosystem/templates/api-ingress.yaml
+++ b/charts/ecosystem/templates/api-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | indent 4 }}
     {{- end }}
-    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:

--- a/charts/ecosystem/templates/api-ingress.yaml
+++ b/charts/ecosystem/templates/api-ingress.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-api
+  annotations:
+    {{- with .Values.ingress.annotations }}
+      {{- toYaml . | indent 4 }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.externalHostname }}
+    {{- if .Values.ingress.tls.secretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.externalHostname }}
+    http:
+      paths:
+      - path: /api(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-api
+            port:
+              number: 8080
+{{- end }}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright contributors to the Galasa project 
+# Copyright contributors to the Galasa project
 #
 apiVersion: apps/v1
 kind: Deployment
@@ -83,7 +83,7 @@ spec:
         image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["java"]
-        args: 
+        args:
         - -jar
         - boot.jar
         - --obr
@@ -101,6 +101,8 @@ spec:
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
+        - name: GALASA_DEX_ISSUER
+          value: {{ .Values.dex.config.issuer }}
         ports:
         - containerPort: 9010
           name: metrics
@@ -128,7 +130,7 @@ spec:
           mountPath: /galasa/load/dev.galasa.testcatalog.cfg
           subPath: dev.galasa.testcatalog.cfg
         - name: data
-          mountPath: /galasa/testcatalog    
+          mountPath: /galasa/testcatalog
       volumes:
       - name: bootstrap
         configMap:

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -1,9 +1,17 @@
 #
-# Copyright contributors to the Galasa project 
+# Copyright contributors to the Galasa project
 #
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-dex-config
 data:
-  config.yaml: {{ .Values.dex.config | toYaml | quote }}
+  config.yaml: |-
+    {{ .Values.dex.config | toYaml | nindent 4 }}
+    {{- if not (hasKey .Values.dex.config "storage") }}
+    storage:
+      type: etcd
+      config:
+        endpoints:
+          - http://{{ .Release.Name }}-etcd:2379
+    {{- end }}

--- a/charts/ecosystem/templates/dex.yaml
+++ b/charts/ecosystem/templates/dex.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright contributors to the Galasa project 
+# Copyright contributors to the Galasa project
 #
 apiVersion: apps/v1
 kind: Deployment
@@ -19,6 +19,17 @@ spec:
 
     spec:
       serviceAccountName: galasa
+      initContainers:
+      - name: wait-for-etcd
+        image: bitnami/kubectl
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-etcd
+          - --for=condition=Ready
+          - --timeout=90s
       containers:
       - image: {{ .Values.dexImage }}
         name: dex

--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright contributors to the Galasa project 
+# Copyright contributors to the Galasa project
 #
 {{- if not (lookup "v1" "ServiceAccount" .Release.Namespace "galasa") }}
 apiVersion: v1
@@ -39,35 +39,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: galasa
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: galasa-dex
-rules:
-- apiGroups: ["dex.coreos.com"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["list", "create"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: galasa-dex
-roleRef:
-  kind: ClusterRole
-  name: galasa-dex
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  namespace: {{ .Release.Namespace }}
   name: galasa
 
 {{- end }}

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -62,6 +62,11 @@ ingress:
   # Enables/disables the use of ingress
   enabled: true
 
+  # Values to configure the use of TLS in ingresses
+  tls:
+    enabled: false
+    secretName: ""
+
   # Annotations to be added to ingresses
   annotations: {}
 #

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright contributors to the Galasa project 
+# Copyright contributors to the Galasa project
 #
 #
 # The External host name the Kubernetes NodePorts can be accessed on, can be an IP address
@@ -66,26 +66,23 @@ ingress:
 # Values to configure the ecosystem's use of Dex
 #
 dex:
-  # NodePorts to access Dex services through (Helm will dynamically assign NodePorts in the 
+  # NodePorts to access Dex services through (Helm will dynamically assign NodePorts in the
   # 30000 to 32767 range if they are left blank).
   nodePorts:
     grpc: 32000
     http: # blank - dynamically assigned
 
   # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
+  # By default, etcd is used as the storage option for the Galasa Ecosystem.
   config:
     issuer: http://example.com/dex
-    storage:
-      type: kubernetes
-      config:
-        inCluster: true
 
     # Enable Dex's gRPC API for clients to interact with.
     grpc:
       # The address of the exposed gRPC API server. Must be a valid {HOST}:{PORT} combination.
       addr: example.com:32000
       reflection: true
-    
+
     # Default is set to use an example email and password.
     enablePasswordDB: true
     staticPasswords:


### PR DESCRIPTION
Remove the need to have permissions to create ClusterRole and ClusterRoleBindings by configuring Dex to use the ecosystem's etcd cluster as its backing store.

Signed-off-by: Eamonn Mansour <47121388+eamansour@users.noreply.github.com>

Note: Builds will fail until the helm pipelines are created.