### PR TITLE
Update README and move communications with Dex to the API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,12 @@ To configure Dex in your ecosystem, update your values.yaml file according to th
           secretEnv: WEBUI_CLIENT_SECRET
     ```
 
-4. If desired, update the `expiry` section to configure the expiry of JSON Web Tokens (JWTs) and refresh tokens issued by Dex. By default, JWTs expire one day after being issued and refresh tokens remain valid unless they have not been used for 1 year. See the Dex's documentation on [ID tokens](https://dexidp.io/docs/id-tokens) for information and available expiry settings.
+4. If desired, update the `expiry` section to configure the expiry of JSON Web Tokens (JWTs) and refresh tokens issued by Dex. By default, JWTs expire 24 hours after being issued and refresh tokens remain valid unless they have not been used for one year. See the Dex's documentation on [ID tokens](https://dexidp.io/docs/id-tokens) for information and available expiry settings.
 
-Next, you will need to configure Dex to authenticate via a connector to authenticate with an upstream identity provider like GitHub, Microsoft, or an LDAP server. For a full list of supported connectors, refer to the [Dex documentation](https://dexidp.io/docs/connectors). In this guide, we will configure dex to authenticate through GitHub:
+Next, you will need to configure Dex to authenticate via a connector to authenticate with an upstream identity provider like GitHub, Microsoft, or an LDAP server. For a full list of supported connectors, refer to the [Dex documentation](https://dexidp.io/docs/connectors). In this guide, we will configure Dex to authenticate through GitHub:
 
-1. Register an OAuth application in [GitHub](https://github.com/settings/applications/new), ensuring the application's callback URL is set to your Dex `issuer` value followed by `/callback` (i.e. `<your-dex-issuer-url>/callback`).
+1. Register an OAuth application in [GitHub](https://github.com/settings/applications/new), ensuring the application's callback URL is set to your Dex `issuer` value followed by `/callback`. For example, if your `issuer` value is `https://prod-ecosystem.galasa.dev/dex`, then your callback URL would be `https://prod-ecosystem.galasa.dev/dex/callback`.
+
 2. Add a GitHub connector to your Dex configuration, providing the name of your GitHub organisation and any teams that you require users to be part of to be able to use your ecosystem as follows:
 
     ```yaml
@@ -137,7 +138,7 @@ Next, you will need to configure Dex to authenticate via a connector to authenti
     ```
     where `$GITHUB_CLIENT_ID` and `$GITHUB_CLIENT_SECRET` correspond to the registered OAuth application's client ID and secret. Also ensure that the `redirectURI` value is the same value that you provided when setting up your GitHub OAuth application in step 1.
 
-    If you would like to draw the client ID and secret values of your OAuth application from a Kubernetes Secret, create a Secret by running the following `kubectl` command, ensuring the Secret's keys match those given in the GitHub connector's `clientID` and `clientSecret` values without the leading `$` (i.e. `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in our example):
+    If you would like to pull the client ID and secret values of your OAuth application from a Kubernetes Secret, create a Secret by running the following `kubectl` command, ensuring the Secret's keys match those given in the GitHub connector's `clientID` and `clientSecret` values without the leading `$` (i.e. `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in the following example):
 
     ```bash
     kubectl create secret generic my-github-oauth-app-credentials \
@@ -172,7 +173,7 @@ Next, you will need to configure Dex to authenticate via a connector to authenti
 
 By default, the Galasa Ecosystem Helm chart will create a Kubernetes Secret containing configuration details for Dex. If you would like to apply your own Dex configuration as a Secret, your Dex configuration must be provided in a `config.yaml` key within the Secret and the value of the `config.yaml` key must be a valid Dex configuration.
 
-For more information on configuring dex, refer to the [Dex documentation](https://dexidp.io/docs).
+For more information on configuring Dex, refer to the [Dex documentation](https://dexidp.io/docs).
 
 Having configured your [values.yaml](charts/ecosystem/values.yaml) file, use the following command to install the Galasa Ecosystem Helm chart:
 

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -73,6 +73,17 @@ spec:
           - -l=app={{ .Release.Name }}-ras
           - --for=condition=Ready
           - --timeout=90s
+      - name: wait-for-dex
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-dex
+          - --for=condition=Ready
+          - --timeout=90s
       {{- if .Values.ingress.caCertSecretName }}
       - name: import-ca-certs
         image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
@@ -87,7 +98,7 @@ spec:
             java_cacerts_file=${JAVA_HOME}/lib/security/cacerts
             certs_dir=/etc/ssl/certs
             cacerts_shared=/cacerts
-            
+
             # Copy the default Java cacerts file into the shared volume
             cp "${java_cacerts_file}" "${cacerts_shared}"
 
@@ -144,6 +155,10 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_DEX_ISSUER
           value: {{ .Values.dex.config.issuer }}
+        - name: GALASA_DEX_GRPC_HOSTNAME
+          value: {{ .Release.Name }}-dex:5557
+        - name: GALASA_EXTERNAL_API_URL
+          value: {{ empty .Values.ingress.tls | ternary "http" "https" }}://{{ .Values.externalHostname }}/api
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -22,5 +22,6 @@ stringData:
       config:
         endpoints:
           - http://{{ .Release.Name }}-etcd:2379
+        namespace: dex.
     {{- end }}
 {{- end }}

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -12,6 +12,10 @@ type: Opaque
 stringData:
   config.yaml: |-
     {{ .Values.dex.config | toYaml | nindent 4 }}
+    grpc:
+      addr: "{{ .Release.Name }}-dex:5557"
+      reflection: true
+
     {{- if not (hasKey .Values.dex.config "storage") }}
     storage:
       type: etcd

--- a/charts/ecosystem/templates/dex-service-external.yaml
+++ b/charts/ecosystem/templates/dex-service-external.yaml
@@ -25,9 +25,6 @@ spec:
   - name: grpc
     port: 5557
     targetPort: 5557
-    {{- if .Values.dex.nodePorts.grpc }}
-    nodePort: {{ .Values.dex.nodePorts.grpc }}
-    {{- end }}
     protocol: TCP
   - name: telemetry
     port: 5558

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -30,7 +30,7 @@ spec:
 {{ toYaml .Values.nodeSelectors | indent 8 }}
         {{- end }}
       initContainers:
-        - name: wait-for-dex
+        - name: wait-for-api
           image: {{ .Values.kubectlImage }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command:
@@ -38,22 +38,20 @@ spec:
           args:
             - wait
             - pods
-            - -l=app={{ .Release.Name }}-dex
+            - -l=app={{ .Release.Name }}-api
             - --for=condition=Ready
-            - --timeout=180s
+            - --timeout=240s
       containers:
       - name: webui
         image: {{ .Values.galasaRegistry }}/galasa-ui:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
-        - name: DEX_ISSUER_URL
-          value: {{ .Values.dex.config.issuer }}
-        - name: DEX_GRPC_HOSTNAME
-          value: {{ .Values.dex.config.grpc.addr }}
-        - name: WEBUI_HOST_URL
-          value: https://{{ .Values.externalHostname }}
+        - name: GALASA_API_SERVER_URL
+          value: http://{{ .Release.Name }}-api:8080
+        - name: GALASA_WEBUI_HOST_URL
+          value: {{ empty .Values.ingress.tls | ternary "http" "https" }}://{{ .Values.externalHostname }}
         {{- with (first .Values.dex.config.staticClients) }}
-        - name: DEX_CLIENT_SECRET
+        - name: GALASA_WEBUI_CLIENT_SECRET
           {{- if .secretEnv }}
           value: $({{ .secretEnv }})
           {{- else }}
@@ -62,7 +60,7 @@ spec:
         {{- end }}
         {{- if .Values.ingress.caCertSecretName }}
         - name: NODE_EXTRA_CA_CERTS
-          value: /etc/ssl/certs/cacerts.pem
+          value: /etc/ssl/certs/cacerts/cacerts.pem
         {{- end }}
         {{- with .Values.dex.envFrom }}
         envFrom:
@@ -86,8 +84,7 @@ spec:
       {{- if .Values.ingress.caCertSecretName }}
         volumeMounts:
           - name: cacert-store
-            mountPath: /etc/ssl/certs/cacerts.pem
-            subPath: cacerts.pem
+            mountPath: /etc/ssl/certs/cacerts
       volumes:
         - name: cacert-store
           secret:

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -51,6 +51,8 @@ spec:
         - name: GALASA_WEBUI_HOST_URL
           value: {{ empty .Values.ingress.tls | ternary "http" "https" }}://{{ .Values.externalHostname }}
         {{- with (first .Values.dex.config.staticClients) }}
+        - name: GALASA_WEBUI_CLIENT_ID
+          value: {{ .id }}
         - name: GALASA_WEBUI_CLIENT_SECRET
           {{- if .secretEnv }}
           value: $({{ .secretEnv }})

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -74,7 +74,7 @@ ingress:
   #     - "*.example.com"
   #     secretName: mysecret
   tls: {}
-  
+
   # The name of the Secret containing root and intermediate CA certificates in a single .pem file
   caCertSecretName: ""
 
@@ -121,12 +121,6 @@ dex:
   # By default, etcd is used as the storage option for the Galasa Ecosystem.
   config:
     issuer: "http://example.com/dex"
-
-    # Enable Dex's gRPC API for clients to interact with.
-    grpc:
-      # The address of the exposed gRPC API server. Must be a valid {HOST}:{PORT} combination.
-      addr: "example.com:32000"
-      reflection: true
 
     # OAuth 2.0 configuration values. By default, Dex has been configured to skip the additional
     # access approval screen after logging in to the Galasa Ecosystem.

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -114,7 +114,6 @@ dex:
   # NodePorts to access Dex services through (Helm will dynamically assign NodePorts in the
   # 30000 to 32767 range if they are left blank).
   nodePorts:
-    grpc: 32000
     http: # blank - dynamically assigned
 
   # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1568
Note: The main build pipeline to redeploy ecosystem1 will fail until this PR is merged

Main changes:
- Updated README with initial draft of up-to-date instructions on how to configure Ingress and Dex
- Set correct environment variables in the API server so that it can talk to Dex
- Removed Dex-related environment variables from the webui
- Added `dex.` namespace for Dex's etcd storage
- Moved Dex gRPC API config out of values.yaml and into the baked-in Dex config since it doesn't need to be configured by the user