### PR TITLE
Bump ecosystem chart to 0.32.0

### DIFF
--- a/charts/ecosystem/Chart.yaml
+++ b/charts/ecosystem/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 #
 home: "galasa.dev"
 #
-version: "0.26.0"
+version: "0.32.0"


### PR DESCRIPTION
Bumps the Galasa Ecosystem chart version from 0.26.0 to 0.32.0