### PR TITLE
Iss1777 - Update workflow to release/prerelease helm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,8 @@ jobs:
         if: (github.ref == 'refs/heads/prerelease')
         uses: helm/chart-releaser-action@main
         with: 
-          skip_existing: true
-          skip_packaging: true
-          skip_upload: true
+          skip_existing: true # Skip package upload if release/tag already exists
+          skip_upload: true # Skips upload to index.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -39,6 +38,6 @@ jobs:
         if: (github.ref == 'refs/heads/release')
         uses: helm/chart-releaser-action@main
         with:
-          skip_existing: true
+          skip_existing: true # Skip package upload if release/tag already exists
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,9 @@ jobs:
         if: (github.ref == 'refs/heads/prerelease')
         uses: helm/chart-releaser-action@main
         with: 
-          skip_upload: true
           skip_existing: true
+          skip_packaging: true
+          skip_upload: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,8 @@ name: Release Charts
 on:
   push:
     branches:
-      - released
+      - prerelease
+      - release
 
 jobs:
   release:
@@ -25,6 +26,15 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
+        if: (github.ref == 'refs/heads/prerelease')
+        uses: helm/chart-releaser-action@v1.1.0
+        with: 
+          skip_upload: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run chart-releaser
+        if: (github.ref == 'refs/heads/release')
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run chart-releaser
         if: (github.ref == 'refs/heads/prerelease')
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.6.0
         with: 
           skip_upload: true
         env:
@@ -35,6 +35,6 @@ jobs:
 
       - name: Run chart-releaser
         if: (github.ref == 'refs/heads/release')
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
+      - name: Run chart-releaser - pre-release
         if: (github.ref == 'refs/heads/prerelease')
         uses: helm/chart-releaser-action@main
         with: 
@@ -34,7 +34,7 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Run chart-releaser
+      - name: Run chart-releaser - release
         if: (github.ref == 'refs/heads/release')
         uses: helm/chart-releaser-action@main
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,14 +27,17 @@ jobs:
 
       - name: Run chart-releaser
         if: (github.ref == 'refs/heads/prerelease')
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@main
         with: 
           skip_upload: true
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser
         if: (github.ref == 'refs/heads/release')
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@main
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- Workflow triggered on pushes to 'prerelease' and 'release' which will happen at the start of each prerelease/release
- If doing a prerelease, the skip_upload flag ensures the Release/Tag created aren't added to the index.yaml (manifest sort of file for the releases) which is useful as we are going to delete the Release/Tag from prereleases. This means we don't have to also go in and amend the index.yaml.
- For both prerelease and release, use the skip_existing flag to not repackage and rerelease if a Release/Tag already exists. Unlikely this will happen at the moment where Ecosystem 1's chart is constantly being developed, but if in future, there have been no changes, we don't want to repackage and release for no reason. 
-  Using the 'main' version of the helm/chart-releaser-action because these flags have not yet been released.