### PR TITLE
Add empty connectors value to the dex config

### DIFF
--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -113,6 +113,11 @@ dex:
   config:
     issuer: "http://example.com/dex"
 
+    # Connectors to upstream identity providers that users can authenticate with.
+    # See the [Dex documentation](https://dexidp.io/docs/connectors) for a list
+    # of connectors supported by Dex.
+    connectors: []
+
     # OAuth 2.0 configuration values. By default, Dex has been configured to skip the additional
     # access approval screen after logging in to the Galasa Ecosystem.
     oauth2:


### PR DESCRIPTION
Discovered as part of https://github.com/galasa-dev/projectmanagement/issues/1363

Changes:
- Added an empty `connectors` value with a description to make it clearer as to where the value should be located when configuring Dex.