### PR TITLE
Allow Galasa image names to be passed in as values, remove unused cert import and webui secret

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -84,41 +84,6 @@ spec:
           - -l=app={{ .Release.Name }}-dex
           - --for=condition=Ready
           - --timeout=90s
-      {{- if .Values.ingress.caCertSecretName }}
-      - name: import-ca-certs
-        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsUser: 0
-        command:
-          - /bin/bash
-          - -ec
-          - |
-            java_cacerts_file=${JAVA_HOME}/lib/security/cacerts
-            certs_dir=/etc/ssl/certs
-            cacerts_shared=/cacerts
-
-            # Copy the default Java cacerts file into the shared volume
-            cp "${java_cacerts_file}" "${cacerts_shared}"
-
-            # Import certificates in .pem format
-            for cert_file in ${certs_dir}/*.pem; do
-              alias_name=$(basename "${cert_file}" .pem)
-              keytool -import \
-                -file "${cert_file}" \
-                -alias "${alias_name}" \
-                -keystore "${cacerts_shared}/cacerts" \
-                -storepass "changeit" \
-                -trustcacerts \
-                -noprompt
-            done
-        volumeMounts:
-          - name: cacert-store
-            mountPath: /etc/ssl/certs
-          - name: cacert-share
-            mountPath: /cacerts
-      {{- end }}
       containers:
       - name: api
         image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
@@ -176,10 +141,6 @@ spec:
           subPath: dev.galasa.testcatalog.cfg
         - name: data
           mountPath: /galasa/testcatalog
-        {{- if .Values.ingress.caCertSecretName }}
-        - name: cacert-share
-          mountPath: /usr/local/openjdk-11/lib/security
-        {{- end }}
       volumes:
       - name: bootstrap
         configMap:
@@ -190,10 +151,3 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-pvc-testcatalog
-      {{- if .Values.ingress.caCertSecretName }}
-      - name: cacert-store
-        secret:
-          secretName: {{ .Values.ingress.caCertSecretName }}
-      - name: cacert-share
-        emptyDir: {}
-      {{- end }}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -41,7 +41,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       initContainers:
       - name: init-chown-data
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["chown", "-v", "1000", "/data"]
         volumeMounts:
@@ -86,7 +86,7 @@ spec:
           - --timeout=90s
       {{- if .Values.ingress.caCertSecretName }}
       - name: import-ca-certs
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -121,7 +121,7 @@ spec:
       {{- end }}
       containers:
       - name: api
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["java"]
         args:

--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -23,7 +23,7 @@ data:
 # The label for the engine pods and the prefix of the engine names
   engine_label: "{{ .Release.Name }}-k8s-standard-engine"
 #
-  engine_image: "{{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}"
+  engine_image: "{{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}"
   node_arch: "{{ .Values.architecture }}"
 #  node_arch: ""
 #  node_preferred_affinity: "beta.kubernetes.io/arch=s390x"

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -43,7 +43,7 @@ spec:
             - --timeout=180s
       containers:
       - name: engine-controller
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command:
           - /bin/bash

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -43,7 +43,7 @@ spec:
             - --timeout=180s
       containers:
       - name: metrics
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["java"]
         args: 

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -43,7 +43,7 @@ spec:
             - --timeout=180s
       containers:
       - name: resource-monitor
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["java"]
         args: 

--- a/charts/ecosystem/templates/validation.yaml
+++ b/charts/ecosystem/templates/validation.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: galasa
       containers:
       - name: validate
-        image: {{ .Values.galasaRegistry }}/galasa-boot-embedded-{{ .Values.architecture }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["java"]
         args: 

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -53,12 +53,6 @@ spec:
         {{- with (first .Values.dex.config.staticClients) }}
         - name: GALASA_WEBUI_CLIENT_ID
           value: {{ .id }}
-        - name: GALASA_WEBUI_CLIENT_SECRET
-          {{- if .secretEnv }}
-          value: $({{ .secretEnv }})
-          {{- else }}
-          value: {{ .secret }}
-          {{- end }}
         {{- end }}
         {{- if .Values.ingress.caCertSecretName }}
         - name: NODE_EXTRA_CA_CERTS

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -43,7 +43,7 @@ spec:
             - --timeout=240s
       containers:
       - name: webui
-        image: {{ .Values.galasaRegistry }}/galasa-ui:{{ .Values.galasaVersion }}
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaWebUiImage }}:{{ .Values.galasaVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
         - name: GALASA_API_SERVER_URL

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -23,12 +23,17 @@ galasaVersion: "0.33.0"
 galasaRegistry: "icr.io/galasadev"
 #
 #
+# The name of the Docker image that contains Galasa's boot.jar file to launch ecosystem services
+#
+galasaBootImage: "galasa-boot-embedded-amd64"
+#
+#
 # The pull policy to be used for the Galasa images, only useful for Galasa development purposes
 #
 pullPolicy: "IfNotPresent"
 #
 #
-# The architecture the pods will be run on, at the moment, only adm64 is supported
+# The architecture the pods will be run on, at the moment, only amd64 is supported
 #
 architecture: amd64
 #

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -28,6 +28,11 @@ galasaRegistry: "icr.io/galasadev"
 galasaBootImage: "galasa-boot-embedded-amd64"
 #
 #
+# The name of the Docker image that launches Galasa's web UI
+#
+galasaWebUiImage: "galasa-ui"
+#
+#
 # The pull policy to be used for the Galasa images, only useful for Galasa development purposes
 #
 pullPolicy: "IfNotPresent"
@@ -134,7 +139,7 @@ dex:
       redirectURIs:
       - 'http://example.com/auth/callback'
       name: 'Galasa Ecosystem Web UI'
-      secret: example-webui-client-secret
+      secret: ""
 
     # Token expiry configuration
     expiry:


### PR DESCRIPTION
Related to https://github.com/galasa-dev/projectmanagement/issues/1797

Changes:
- Add `galasaBootImage` and `galasaWebUiImage` values to allow custom galasa images to be passed in as values
  - This will allow users to import any certificates into images and use them in the helm chart
- Removed unused import-ca-certs init container in favour of the above method until certificate storage and handling is implemented in Galasa
- Removed unused `GALASA_WEBUI_CLIENT_SECRET` environment variable from the webui deployment