### PR TITLE
Add usernameClaims value and GALASA_USERNAME_CLAIM env variable

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -113,6 +113,8 @@ spec:
           value: {{ .Release.Name }}-dex:5557
         - name: GALASA_EXTERNAL_API_URL
           value: {{ empty .Values.ingress.tls | ternary "http" "https" }}://{{ .Values.externalHostname }}/api
+        - name: GALASA_USERNAME_CLAIMS
+          value: {{ join "," .Values.dex.usernameClaims | quote }}
         - name: GALASA_RAS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -108,7 +108,8 @@ dex:
     # named "<release-name>-dex-config" will be created.
     secretName: ""
 
-  # `envFrom` represents a list of additional environment variables mounted from Kubernetes Secrets or ConfigMaps.
+  # Optional - `envFrom` represents a list of additional environment variables mounted from Kubernetes Secrets or ConfigMaps
+  # into the Dex Deployment.
   # If you would like to mount an additional environment variable from a Secret or ConfigMap, provide the name of the
   # resource in the `envFrom` list. For example:
   # envFrom:

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -118,6 +118,38 @@ dex:
   #       name: my-env-configmap
   envFrom: []
 
+  # Optional - An ordered list of JSON Web Token (JWT) claims to use when Galasa sets the requestor of a test.
+  # The first JWT claim that is matched will be used as the requestor of a test.
+  #
+  # For example, given a JWT that includes the following claims:
+  # {
+  #   "iss": "https://example.com/dex",
+  #   "sub": "my-user-id",
+  #   "aud": "my-client",
+  #   "exp": 1234567890,
+  #   "iat": 1234567890,
+  #   "name": "John Doe",
+  #   "preferred_username": "johndoe"
+  # }
+  #
+  # If the `usernameClaims` value is set to:
+  #
+  # usernameClaims:
+  #   - name
+  #   - preferred_username
+  #   - sub
+  #
+  # then the "name" claim will be matched first, and the value "John Doe" will be taken as the requestor of a test.
+  #
+  # By default, the order that will be applied is as follows:
+  # 1. "preferred_username"
+  # 2. "name"
+  # 3. "sub"
+  #
+  # Different Dex connectors may return different claims within issued JWTs. For details on which JWT claims are
+  # supported by Dex, refer to the [Dex documentation](https://dexidp.io/docs/custom-scopes-claims-clients).
+  usernameClaims: []
+
   # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
   # By default, etcd is used as the storage option for the Galasa Ecosystem.
   config:


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1816

Changes:
- Added an optional `usernameClaims` value to allow users to configure the JWT claim that should be searched for when Galasa sets the username of an ecosystem user
  - Multiple JWT claims can be provided so that the API server can fall back to other claims that may also contain username values
- Added the `GALASA_USERNAME_CLAIMS` environment variable to the API server, which converts the `usernameClaims` value into a comma-separated list