### PR TITLE
issue 1821 couchdb-secret changes during helm upgrade

### DIFF
--- a/charts/ecosystem/templates/couchdb-secret.yaml
+++ b/charts/ecosystem/templates/couchdb-secret.yaml
@@ -1,11 +1,20 @@
+{{- $user := randAlphaNum 32 }}
+{{- $password := randAlphaNum 32 }}
+{{- $couchdbSecretName := (printf "%s-couchdb-secret" .Release.Name )}}
+
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $couchdbSecretName) }}
+{{- if $existingSecret }}
+{{- $user = printf (index $existingSecret.data "COUCHDB_USER") | b64dec }}
+{{- $password = printf (index $existingSecret.data "COUCHDB_PASSWORD") | b64dec }}
+{{- end -}}
+
+
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-couchdb-secret
+  name: {{ $couchdbSecretName }}
 type: Opaque
 stringData:
-  {{- $user := randAlphaNum 32 }}
-  {{- $password := randAlphaNum 32 }}
   COUCHDB_USER: "{{$user}}"
   COUCHDB_PASSWORD: "{{$password}}"
   GALASA_RAS_TOKEN: "{{ printf "%s:%s" $user $password | b64enc }}"


### PR DESCRIPTION
updated couchdb-secret to check for existing instance and re-use the values from that instead of generating a new one.

Reason:
When an upgrade task is done using the helm chart a new couchdb-secret is created. 
This means that the newly started pods will not use the same secret values as the pods that have not been recycled. As a result this can cause the pods to not be able to talk to couchdb, thus causing the ecosystem to not work as expected.