### PR TITLE
Auto-generate client secret for the webui

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ Assuming your Ingress controller has been set up on your Kubernetes cluster, upd
 2. If you are using HTTPS, add a `tls` configuration within the `ingress` section, specifying the `hosts` list and a `secretName` value corresponding to the name of the Kubernetes Secret that contains your TLS private key and certificate. See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) for information for how to set up TLS.
 
 #### Configuring Dex
-**Note: The ecosystem chart's use of Dex is still under development and is subject to change.**
-
-In a future release, [Dex](https://dexidp.io) will be used to authenticate users attempting to interact with a Galasa Ecosystem.
+As of Galasa version 0.32.0, [Dex](https://dexidp.io) is used to authenticate users attempting to interact with a Galasa Ecosystem.
 
 To configure Dex in your ecosystem, update your values.yaml file according to the following steps:
 
@@ -71,38 +69,7 @@ To configure Dex in your ecosystem, update your values.yaml file according to th
     issuer: http://<your-external-hostname>/dex
     ```
 
-2. Under the `staticClients` value, replace the example hostname given in the `redirectURIs` list with the value you provided in the `externalHostname`, and set the URI scheme to either `http` or `https`. For example:
-
-    ```yaml
-    staticClients:
-    - id: galasa-webui
-      redirectURIs:
-      - 'http://<your-external-hostname>/api/auth/callback'
-      name: 'Galasa Ecosystem Web UI'
-      secret: example-webui-client-secret
-    ```
-3. If you would like to supply a client secret for the webui via a Kubernetes Secret, replace the `secret` key in the `staticClients` section with `secretEnv` and supply the name of your Secret as a value within the `envFrom` section. For example, assuming you have a Secret called `my-webui-client-credentials` with a key called `WEBUI_CLIENT_SECRET` and a value representing a client secret, you would provide the following values:
-
-    ```yaml
-    dex:
-      envFrom:
-        - secretRef:
-          name: my-webui-client-credentials
-
-      # Other Dex-related values...
-
-      config:
-        # Other Dex configuration values...
-
-        staticClients:
-        - id: galasa-webui
-          redirectURIs:
-          - 'http://<your-external-hostname>/auth/callback'
-          name: 'Galasa Ecosystem Web UI'
-          secretEnv: WEBUI_CLIENT_SECRET
-    ```
-
-4. If desired, update the `expiry` section to configure the expiry of JSON Web Tokens (JWTs) and refresh tokens issued by Dex. By default, JWTs expire 24 hours after being issued and refresh tokens remain valid unless they have not been used for one year. See the Dex's documentation on [ID tokens](https://dexidp.io/docs/id-tokens) for information and available expiry settings.
+2. If desired, update the `expiry` section to configure the expiry of JSON Web Tokens (JWTs) and refresh tokens issued by Dex. By default, JWTs expire 24 hours after being issued and refresh tokens remain valid unless they have not been used for one year. See the Dex's documentation on [ID tokens](https://dexidp.io/docs/id-tokens) for information and available expiry settings.
 
 Next, you will need to configure Dex to authenticate via a connector to authenticate with an upstream identity provider like GitHub, Microsoft, or an LDAP server. For a full list of supported connectors, refer to the [Dex documentation](https://dexidp.io/docs/connectors). In this guide, we will configure Dex to authenticate through GitHub:
 

--- a/charts/ecosystem/Chart.yaml
+++ b/charts/ecosystem/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 #
 home: "galasa.dev"
 #
-version: "0.33.0"
+version: "0.34.0"

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -7,13 +7,13 @@
 {{/*
   Returns the URI scheme of the host serving the ecosystem
 */}}
-{{- define "ecosystem.hostScheme" -}}
+{{- define "ecosystem.host.scheme" -}}
   {{- empty .Values.ingress.tls | ternary "http" "https"}}
 {{- end -}}
 
 {{/*
   Returns the external URL of the ecosystem
 */}}
-{{- define "ecosystem.hostUrl" -}}
-  {{- printf "%s://%s" (include "ecosystem.hostScheme" .) (.Values.externalHostname) }}
+{{- define "ecosystem.host.url" -}}
+  {{- printf "%s://%s" (include "ecosystem.host.scheme" .) (.Values.externalHostname) }}
 {{- end -}}

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -5,7 +5,7 @@
 #
 
 {{/*
-  Returns the URL scheme of the host serving this ecosystem
+  Returns the URI scheme of the host serving the ecosystem
 */}}
 {{- define "ecosystem.hostScheme" -}}
   {{- empty .Values.ingress.tls | ternary "http" "https"}}

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+{{/*
+  Returns the URL scheme of the host serving this ecosystem
+*/}}
+{{- define "ecosystem.hostScheme" -}}
+  {{- empty .Values.ingress.tls | ternary "http" "https"}}
+{{- end -}}
+
+{{/*
+  Returns the external URL of the ecosystem
+*/}}
+{{- define "ecosystem.hostUrl" -}}
+  {{- printf "%s://%s" (include "ecosystem.hostScheme" .) (.Values.externalHostname) }}
+{{- end -}}

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -8,7 +8,7 @@
   Returns the URI scheme of the host serving the ecosystem
 */}}
 {{- define "ecosystem.host.scheme" -}}
-  {{- empty .Values.ingress.tls | ternary "http" "https"}}
+  {{- empty .Values.ingress.tls | ternary "http" "https" }}
 {{- end -}}
 
 {{/*

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -112,7 +112,7 @@ spec:
         - name: GALASA_DEX_GRPC_HOSTNAME
           value: {{ .Release.Name }}-dex:5557
         - name: GALASA_EXTERNAL_API_URL
-          value: {{ include "ecosystem.host.url" .}}/api
+          value: {{ include "ecosystem.host.url" . }}/api
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -112,7 +112,7 @@ spec:
         - name: GALASA_DEX_GRPC_HOSTNAME
           value: {{ .Release.Name }}-dex:5557
         - name: GALASA_EXTERNAL_API_URL
-          value: {{ empty .Values.ingress.tls | ternary "http" "https" }}://{{ .Values.externalHostname }}/api
+          value: {{ include "ecosystem.hostUrl" .}}/api
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -112,7 +112,7 @@ spec:
         - name: GALASA_DEX_GRPC_HOSTNAME
           value: {{ .Release.Name }}-dex:5557
         - name: GALASA_EXTERNAL_API_URL
-          value: {{ include "ecosystem.hostUrl" .}}/api
+          value: {{ include "ecosystem.host.url" .}}/api
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/templates/couchdb-secret.yaml
+++ b/charts/ecosystem/templates/couchdb-secret.yaml
@@ -15,6 +15,6 @@ metadata:
   name: {{ $couchdbSecretName }}
 type: Opaque
 stringData:
-  COUCHDB_USER: "{{$user}}"
-  COUCHDB_PASSWORD: "{{$password}}"
+  COUCHDB_USER: "{{ $user }}"
+  COUCHDB_PASSWORD: "{{ $password }}"
   GALASA_RAS_TOKEN: "{{ printf "%s:%s" $user $password | b64enc }}"

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -20,7 +20,7 @@ stringData:
     staticClients:
     - id: galasa-webui
       redirectURIs:
-      - '{{ include "ecosystem.hostUrl" . }}/api/auth/callback'
+      - '{{ include "ecosystem.host.url" . }}/api/auth/callback'
       name: 'Galasa Ecosystem Web UI'
       secret: "{{ randAlphaNum 32 }}"
 

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -16,6 +16,7 @@ stringData:
       addr: "{{ .Release.Name }}-dex:5557"
       reflection: true
 
+    {{- if not (hasKey .Values.dex.config "staticClients") }}
     # A list of known clients that authenticate with Dex
     staticClients:
     - id: galasa-webui
@@ -23,6 +24,7 @@ stringData:
       - '{{ include "ecosystem.host.url" . }}/api/auth/callback'
       name: 'Galasa Ecosystem Web UI'
       secret: "{{ randAlphaNum 32 }}"
+    {{- end }}
 
     {{- if not (hasKey .Values.dex.config "storage") }}
     storage:

--- a/charts/ecosystem/templates/dex-config.yaml
+++ b/charts/ecosystem/templates/dex-config.yaml
@@ -16,6 +16,14 @@ stringData:
       addr: "{{ .Release.Name }}-dex:5557"
       reflection: true
 
+    # A list of known clients that authenticate with Dex
+    staticClients:
+    - id: galasa-webui
+      redirectURIs:
+      - '{{ include "ecosystem.hostUrl" . }}/api/auth/callback'
+      name: 'Galasa Ecosystem Web UI'
+      secret: "{{ randAlphaNum 32 }}"
+
     {{- if not (hasKey .Values.dex.config "storage") }}
     storage:
       type: etcd

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -49,7 +49,7 @@ spec:
         - name: GALASA_API_SERVER_URL
           value: http://{{ .Release.Name }}-api:8080
         - name: GALASA_WEBUI_HOST_URL
-          value: {{ include "ecosystem.hostUrl" .}}
+          value: {{ include "ecosystem.host.url" . }}
         - name: GALASA_WEBUI_CLIENT_ID
           value: galasa-webui
         {{- if .Values.ingress.caCertSecretName }}

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -49,18 +49,12 @@ spec:
         - name: GALASA_API_SERVER_URL
           value: http://{{ .Release.Name }}-api:8080
         - name: GALASA_WEBUI_HOST_URL
-          value: {{ empty .Values.ingress.tls | ternary "http" "https" }}://{{ .Values.externalHostname }}
-        {{- with (first .Values.dex.config.staticClients) }}
+          value: {{ include "ecosystem.hostUrl" .}}
         - name: GALASA_WEBUI_CLIENT_ID
-          value: {{ .id }}
-        {{- end }}
+          value: galasa-webui
         {{- if .Values.ingress.caCertSecretName }}
         - name: NODE_EXTRA_CA_CERTS
           value: /etc/ssl/certs/cacerts/cacerts.pem
-        {{- end }}
-        {{- with .Values.dex.envFrom }}
-        envFrom:
-          {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: 8080

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -5,10 +5,8 @@
 #
 
 #
-# The external host name the Kubernetes NodePorts can be accessed on, can be an IP address if you are not using ingresses
-#
-# If you wish to access your Galasa Ecosystem through ingresses (see the `ingress` value below),
-# this is the host name that will be used and it must not be an IP address
+# The external hostname that the Galasa services can be accessed on via Ingress,
+# must be a valid DNS hostname without a URL scheme (i.e. without "https://").
 #
 externalHostname: "example.com"
 #

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -166,14 +166,6 @@ dex:
     oauth2:
       skipApprovalScreen: true
 
-    # A list of known clients that authenticate with Dex
-    staticClients:
-    - id: galasa-webui
-      redirectURIs:
-      - 'http://example.com/auth/callback'
-      name: 'Galasa Ecosystem Web UI'
-      secret: ""
-
     # Token expiry configuration
     expiry:
       idTokens: 24h


### PR DESCRIPTION
## Why?
Resolves https://github.com/galasa-dev/projectmanagement/issues/1757

## Changes
- Removed the need to register the webui as a client in the values.yaml file, this is now done within the helm chart
  - To avoid breaking existing installations, the auto-generated block for the webui client will only be generated if there is no existing `staticClients` block in the values.yaml file
- Added helper methods to simplify the templates to get the URL of the Galasa API server