### PR TITLE
Increase maximum test engines in ConfigMap

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -18,7 +18,7 @@ data:
 #
 #
 # The maximum running number of automation engines the Engine Controller will start
-  max_engines: "4"
+  max_engines: "10"
 #
 # The label for the engine pods and the prefix of the engine names
   engine_label: "{{ .Release.Name }}-k8s-standard-engine"


### PR DESCRIPTION
## Why?

Increase the maximum number of test engines that can be ran at once - aiming to speed up the total time our regression suite of 55 tests takes for daily runs and release testing.