### PR TITLE
Set up auth store in ecosystem helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ test-dex-5dc7fcb55f-lqv6s                 1/1     Running    0             65s
 test-engine-controller-56fb476f45-msj4x   0/1     Init:0/1   0             65s
 test-etcd-0                               1/1     Running    0             65s
 test-metrics-5fd9f687b6-rwcww             0/1     Init:0/1   0             65s
-test-ras-0                                1/1     Running    0             65s
+test-couchdb-0                            1/1     Running    0             65s
 test-resource-monitor-778c647995-x75z9    0/1     Init:0/1   0             65s
 test-webui-6c896974d8-2k2tk               1/1     Running    0             65s
 ```

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -122,6 +122,11 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_AUTHSTORE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-couchdb-secret
+              key: GALASA_RAS_TOKEN
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -62,7 +62,7 @@ spec:
           - -l=app={{ .Release.Name }}-etcd
           - --for=condition=Ready
           - --timeout=90s
-      - name: wait-for-ras
+      - name: wait-for-couchdb
         image: {{ .Values.kubectlImage }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command:
@@ -70,7 +70,7 @@ spec:
         args:
           - wait
           - pods
-          - -l=app={{ .Release.Name }}-ras
+          - -l=app={{ .Release.Name }}-couchdb
           - --for=condition=Ready
           - --timeout=90s
       - name: wait-for-dex

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -105,6 +105,8 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RESULTARCHIVE_STORE
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
+        - name: GALASA_AUTH_STORE
+          value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_DEX_ISSUER

--- a/charts/ecosystem/templates/bootstrap-config.yaml
+++ b/charts/ecosystem/templates/bootstrap-config.yaml
@@ -10,5 +10,5 @@ metadata:
   name: {{ .Release.Name }}-bootstrap-file
 data:
   bootstrap.properties: |
-    framework.config.store=etcd:http://etcd:2379
-    framework.extra.bundles=dev.galasa.cps.etcd,dev.galasa.ras.couchdb
+    framework.config.store=etcd:http://{{ .Release.Name }}-etcd:2379
+    framework.extra.bundles=dev.galasa.cps.etcd,dev.galasa.ras.couchdb,dev.galasa.auth.couchdb

--- a/charts/ecosystem/templates/couchdb-service-internal.yaml
+++ b/charts/ecosystem/templates/couchdb-service-internal.yaml
@@ -17,4 +17,4 @@ spec:
   - port: 4369
     name: erlangport
   selector:
-    app: {{ .Release.Name }}-ras
+    app: {{ .Release.Name }}-couchdb

--- a/charts/ecosystem/templates/couchdb.yaml
+++ b/charts/ecosystem/templates/couchdb.yaml
@@ -7,20 +7,20 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-ras
+  name: {{ .Release.Name }}-couchdb
   labels:
-    name: {{ .Release.Name }}-ras
+    name: {{ .Release.Name }}-couchdb
 spec:
-  serviceName: {{ .Release.Name }}-ras
+  serviceName: {{ .Release.Name }}-couchdb
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-ras
+      app: {{ .Release.Name }}-couchdb
   template:
     metadata:
-      name: {{ .Release.Name }}-ras
+      name: {{ .Release.Name }}-couchdb
       labels:
-        app: {{ .Release.Name }}-ras
+        app: {{ .Release.Name }}-couchdb
     spec:
       nodeSelector:
         kubernetes.io/arch: {{ .Values.architecture }}

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -64,6 +64,8 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RESULTARCHIVE_STORE
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
+        - name: GALASA_AUTH_STORE
+          value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -73,6 +73,11 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_AUTHSTORE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-couchdb-secret
+              key: GALASA_RAS_TOKEN
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -62,6 +62,8 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RESULTARCHIVE_STORE
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
+        - name: GALASA_AUTH_STORE
+          value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -71,6 +71,11 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_AUTHSTORE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-couchdb-secret
+              key: GALASA_RAS_TOKEN
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -74,6 +74,11 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_AUTHSTORE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-couchdb-secret
+              key: GALASA_RAS_TOKEN
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -65,6 +65,8 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RESULTARCHIVE_STORE
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
+        - name: GALASA_AUTH_STORE
+          value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -121,7 +121,7 @@ dex:
   #       name: my-env-configmap
   envFrom: []
 
-  # Optional - An ordered list of JSON Web Token (JWT) claims to use when Galasa sets the requestor of a test.
+  # An ordered list of JSON Web Token (JWT) claims to use when Galasa sets the requestor of a test.
   # The first JWT claim that is matched will be used as the requestor of a test.
   #
   # For example, given a JWT that includes the following claims:

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -151,7 +151,10 @@ dex:
   #
   # Different Dex connectors may return different claims within issued JWTs. For details on which JWT claims are
   # supported by Dex, refer to the [Dex documentation](https://dexidp.io/docs/custom-scopes-claims-clients).
-  usernameClaims: []
+  usernameClaims:
+    - "preferred_username"
+    - "name"
+    - "sub"
 
   # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
   # By default, etcd is used as the storage option for the Galasa Ecosystem.


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1805

## Changes
- Set the `GALASA_AUTH_STORE` environment variable in deployments to point to the existing CouchDB server
- Added the `dev.galasa.auth.couchdb` bundle to be loaded as an extra bundle in the ecosystem
- Added the `GALASA_AUTHSTORE_TOKEN` environment variable to access the CouchDB server using the same basic authentication token as the `GALASA_RAS_TOKEN` (since the auth store and RAS currently use the same CouchDB server)