### PR TITLE
Revert renaming ras StatefulSet to couchdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ test-dex-5dc7fcb55f-lqv6s                 1/1     Running    0             65s
 test-engine-controller-56fb476f45-msj4x   0/1     Init:0/1   0             65s
 test-etcd-0                               1/1     Running    0             65s
 test-metrics-5fd9f687b6-rwcww             0/1     Init:0/1   0             65s
-test-couchdb-0                            1/1     Running    0             65s
+test-ras-0                                1/1     Running    0             65s
 test-resource-monitor-778c647995-x75z9    0/1     Init:0/1   0             65s
 test-webui-6c896974d8-2k2tk               1/1     Running    0             65s
 ```

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -62,7 +62,7 @@ spec:
           - -l=app={{ .Release.Name }}-etcd
           - --for=condition=Ready
           - --timeout=90s
-      - name: wait-for-couchdb
+      - name: wait-for-ras
         image: {{ .Values.kubectlImage }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command:
@@ -70,7 +70,7 @@ spec:
         args:
           - wait
           - pods
-          - -l=app={{ .Release.Name }}-couchdb
+          - -l=app={{ .Release.Name }}-ras
           - --for=condition=Ready
           - --timeout=90s
       - name: wait-for-dex

--- a/charts/ecosystem/templates/couchdb-service-internal.yaml
+++ b/charts/ecosystem/templates/couchdb-service-internal.yaml
@@ -17,4 +17,4 @@ spec:
   - port: 4369
     name: erlangport
   selector:
-    app: {{ .Release.Name }}-couchdb
+    app: {{ .Release.Name }}-ras

--- a/charts/ecosystem/templates/couchdb.yaml
+++ b/charts/ecosystem/templates/couchdb.yaml
@@ -7,20 +7,20 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-couchdb
+  name: {{ .Release.Name }}-ras
   labels:
-    name: {{ .Release.Name }}-couchdb
+    name: {{ .Release.Name }}-ras
 spec:
-  serviceName: {{ .Release.Name }}-couchdb
+  serviceName: {{ .Release.Name }}-ras
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-couchdb
+      app: {{ .Release.Name }}-ras
   template:
     metadata:
-      name: {{ .Release.Name }}-couchdb
+      name: {{ .Release.Name }}-ras
       labels:
-        app: {{ .Release.Name }}-couchdb
+        app: {{ .Release.Name }}-ras
     spec:
       nodeSelector:
         kubernetes.io/arch: {{ .Values.architecture }}


### PR DESCRIPTION
## Why?
Reverting a change made as part of https://github.com/galasa-dev/helm/pull/24

Renaming the `ras` StatefulSet to `couchdb` also creates a new PVC, which means data stored in the original RAS PVC will be lost. So keeping it as `ras` for now.