### PR TITLE
Add GALASA_RAS_TOKEN to validation job

### DIFF
--- a/charts/ecosystem/templates/validation.yaml
+++ b/charts/ecosystem/templates/validation.yaml
@@ -46,3 +46,9 @@ spec:
         - --validateeco
         - --bootstrap
         - http://{{ .Release.Name }}-api:8080/bootstrap
+        env:
+        - name: GALASA_RAS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-couchdb-secret
+              key: GALASA_RAS_TOKEN


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1886

## Changes
- Added the `GALASA_RAS_TOKEN` as an env variable in the validation job that runs when performing `helm test <release-name>` to resolve 401 errors when validating CouchDB databases