### PR TITLE
Assign 30GB of space for etcd by default and turn on auto-compaction

### DIFF
--- a/charts/ecosystem/templates/etcd.yaml
+++ b/charts/ecosystem/templates/etcd.yaml
@@ -178,6 +178,9 @@ spec:
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state new \
                 --data-dir /var/run/etcd/default.etcd
+            
+            # Turn on automatic compaction
+            exec etcd --auto-compaction-retention={{ .Values.etcdHistoryRetention }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -55,9 +55,14 @@ nodeSelectors: {}
 storageClass: ""
 #
 #
+# The number of hours worth of etcd history to retain when etcd is compacted
+#
+etcdHistoryRetention: 10
+#
+#
 # The size of the persistent volumes for the data stores
 #
-etcdDiskSize: "1Gi"
+etcdDiskSize: "30Gi"
 couchdbDiskSize: "10Gi"
 catalogDiskSize: "1Gi"
 #


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1861

## Changes
- Upped the default etcd PVC size from 1GB to 30GB
- Enabled etcd automatic history compaction and added a value to configure the number of hours worth of history to be kept when compacting etcd - by default, this is set to 10 hours.