### PR TITLE
Add api.extra.bundles bootstrap prop and remove auth store from metrics and resource monitor

### DIFF
--- a/charts/ecosystem/templates/bootstrap-config.yaml
+++ b/charts/ecosystem/templates/bootstrap-config.yaml
@@ -11,4 +11,5 @@ metadata:
 data:
   bootstrap.properties: |
     framework.config.store=etcd:http://{{ .Release.Name }}-etcd:2379
-    framework.extra.bundles=dev.galasa.cps.etcd,dev.galasa.ras.couchdb,dev.galasa.auth.couchdb
+    framework.extra.bundles=dev.galasa.cps.etcd,dev.galasa.ras.couchdb
+    api.extra.bundles=dev.galasa.auth.couchdb

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -62,16 +62,9 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RESULTARCHIVE_STORE
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
-        - name: GALASA_AUTH_STORE
-          value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RAS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-couchdb-secret
-              key: GALASA_RAS_TOKEN
-        - name: GALASA_AUTHSTORE_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -65,16 +65,9 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RESULTARCHIVE_STORE
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
-        - name: GALASA_AUTH_STORE
-          value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_RAS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-couchdb-secret
-              key: GALASA_RAS_TOKEN
-        - name: GALASA_AUTHSTORE_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1864

## Changes
- Added `api.extra.bundles` property into bootstrap configmap to load the `dev.galasa.auth.couchdb` bundle into the API server
- Removed unnecessary auth store-related env variables from metrics and resource monitor now that the auth store will only be initialised in the API server