### PR TITLE
Add event streams token as env var to API and Engine Controller

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -127,6 +127,11 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_EVENT_STREAMS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-{{ .Values.eventStreamsSecretName }}
+              key: GALASA_EVENT_STREAMS_TOKEN
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -132,7 +132,7 @@ spec:
         - name: GALASA_EVENT_STREAMS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-{{ .Values.eventStreamsSecretName }}
+              name: {{- if .Values.eventStreamsSecretName }}{{ .Values.eventStreamsSecretName }}{{- else }}{{ .Release.Name }}-event-streams-token{{- end }}
               key: GALASA_EVENT_STREAMS_TOKEN
         ports:
         - containerPort: 9010

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - name: GALASA_EVENT_STREAMS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-{{ .Values.eventStreamsSecretName }}
+              name: {{- if .Values.eventStreamsSecretName }}{{ .Values.eventStreamsSecretName }}{{- else }}{{ .Release.Name }}-event-streams-token{{- end }}
               key: GALASA_EVENT_STREAMS_TOKEN
         ports:
         - containerPort: 9010

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -78,6 +78,11 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_EVENT_STREAMS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-{{ .Values.eventStreamsSecretName }}
+              key: GALASA_EVENT_STREAMS_TOKEN
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -1,11 +1,11 @@
+# eventStreamsSecretName set in values.yaml so use that Secret name for the lookup
 {{- if .Values.eventStreamsSecretName }}
 
-{{- $eventStreamsSecretName := (printf "%s-%s" .Release.Name .Values.eventStreamsSecretName) }}
-
-{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $eventStreamsSecretName) }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace .Values.eventStreamsSecretName) }}
 
 {{- if not $existingSecret }}
 
+{{- $eventStreamsSecretName := (printf "%s-%s" .Release.Name "event-streams-token") }}
 {{- $token := randAlphaNum 44 }}
 
 apiVersion: v1
@@ -17,5 +17,19 @@ stringData:
   GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
 
 {{- end -}}
+
+# eventStreamsSecretName not set in values.yaml so generate a name and a Secret
+{{- else }}
+
+{{- $eventStreamsSecretName := (printf "%s-%s" .Release.Name "event-streams-token") }}
+{{- $token := randAlphaNum 44 }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $eventStreamsSecretName }}
+type: Opaque
+stringData:
+  GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
 
 {{- end }}

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.eventStreamsSecretName }}
+
+{{- $eventStreamsSecretName := (printf "%s-%s" .Release.Name .Values.eventStreamsSecretName) }}
+
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $eventStreamsSecretName) }}
+
+{{- if not $existingSecret }}
+
+{{- $token := randAlphaNum 44 }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $eventStreamsSecretName }}
+type: Opaque
+stringData:
+  GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
+
+{{- end -}}
+
+{{- end }}

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -182,3 +182,5 @@ dex:
       refreshTokens:
         reuseInterval: 8760h # 1 year
         validIfNotUsedFor: 8760h # 1 year
+
+eventStreamsSecretName: "event-streams-token"


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1893

Helps the Kafka plugin authenticate to the Event Streams instance as it consumes the token from the System environment. 

This checks if the Secret exists (it will as I'll manually create it) and so should ignore the new creation of the Secret as part of the Chart. This will need discussing with the team about how we move forward in future.