### PR TITLE
Add value for allowed API server request origins

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -117,6 +117,8 @@ spec:
           value: {{ include "ecosystem.host.url" . }}/api
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
+        - name: GALASA_ALLOWED_ORIGINS
+          value: {{ join "," .Values.allowedOrigins | quote }}
         - name: GALASA_RAS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -13,7 +13,7 @@ externalHostname: "example.com"
 # The version of Galasa you want to run with, it is better that you do not use "latest" to ensure
 # all the components are running the same version and a controlled upgrade can be performed
 #
-galasaVersion: "0.33.0"
+galasaVersion: "0.34.0"
 #
 #
 # The container registry the Galasa images can be found in

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -75,6 +75,19 @@ dexImage: "ghcr.io/dexidp/dex:v2.38.0"
 kubectlImage: "bitnami/kubectl:1.28"
 #
 #
+# A list of origins that are allowed to receive responses from the Galasa API server.
+# To limit the origins to a set of domains, you can use a wildcard (*) value.
+#
+# For example, to allow all subdomains of example.com, you can use the following value:
+# allowedOrigins:
+#   - "*.example.com"
+#
+# By default, all origins are allowed.
+#
+allowedOrigins:
+  - "*"
+#
+#
 # Values to enable and configure the use of ingress
 # Note: The externalHostname value must be a valid DNS name for ingress to be used.
 #


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1895

## Changes
- Added a new `allowedOrigins` list that indicates the origins that are permitted to receive responses from the Galasa API server.
  - By default, this value is set to allow all origins (i.e. `*`)