### PR TITLE
Add set-version script for the ecosystem helm chart and bump to 0.34.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.DS_Store
 .vscode/*
+temp/

--- a/charts/ecosystem/Chart.yaml
+++ b/charts/ecosystem/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 #
 home: "galasa.dev"
 #
-version: "0.34.0"
+version: "0.34.1"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -13,7 +13,7 @@ externalHostname: "example.com"
 # The version of Galasa you want to run with, it is better that you do not use "latest" to ensure
 # all the components are running the same version and a controlled upgrade can be performed
 #
-galasaVersion: "0.34.0"
+galasaVersion: "0.34.1"
 #
 #
 # The container registry the Galasa images can be found in

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,104 @@
+#! /usr/bin/env bash 
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Sets the version number of this component.
+#
+# Environment variable over-rides:
+# None
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+export ORIGINAL_DIR=$(pwd)
+
+cd "${BASEDIR}/.."
+WORKSPACE_DIR=$(pwd)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
+
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    h1 "Syntax"
+    cat << EOF
+set-version.sh [OPTIONS]
+Options are:
+-v | --version xxx : Mandatory. Set the ecosystem Helm chart's version number to something explicitly. 
+    For example '--version 0.35.0'
+EOF
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------                   
+component_version=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -v | --version )        shift
+                                export component_version=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+if [[ -z $component_version ]]; then 
+    error "Missing mandatory '--version' argument."
+    usage
+    exit 1
+fi
+
+temp_dir=$BASEDIR/temp/version_bump
+mkdir -p $temp_dir
+
+# Ecosystem Chart.yaml
+cat $BASEDIR/charts/ecosystem/Chart.yaml | sed "s/version: .*/version: \"$component_version\"/1" > $temp_dir/Chart.yaml
+cp $temp_dir/Chart.yaml $BASEDIR/charts/ecosystem/Chart.yaml
+
+# Ecosystem values.yaml
+cat $BASEDIR/charts/ecosystem/values.yaml | sed "s/galasaVersion: .*/galasaVersion: \"$component_version\"/1" > $temp_dir/values.yaml
+cp $temp_dir/values.yaml $BASEDIR/charts/ecosystem/values.yaml

--- a/set-version.sh
+++ b/set-version.sh
@@ -96,9 +96,9 @@ temp_dir=$BASEDIR/temp/version_bump
 mkdir -p $temp_dir
 
 # Ecosystem Chart.yaml
-cat $BASEDIR/charts/ecosystem/Chart.yaml | sed "s/version: .*/version: \"$component_version\"/1" > $temp_dir/Chart.yaml
+cat $BASEDIR/charts/ecosystem/Chart.yaml | sed "s/version:.*/version: \"$component_version\"/1" > $temp_dir/Chart.yaml
 cp $temp_dir/Chart.yaml $BASEDIR/charts/ecosystem/Chart.yaml
 
 # Ecosystem values.yaml
-cat $BASEDIR/charts/ecosystem/values.yaml | sed "s/galasaVersion: .*/galasaVersion: \"$component_version\"/1" > $temp_dir/values.yaml
+cat $BASEDIR/charts/ecosystem/values.yaml | sed "s/galasaVersion:.*/galasaVersion: \"$component_version\"/1" > $temp_dir/values.yaml
 cp $temp_dir/values.yaml $BASEDIR/charts/ecosystem/values.yaml


### PR DESCRIPTION
## Why?
Adds a set-version script similar to the other Galasa components to simplify the process of bumping the ecosystem chart's version during releases, and bumps the Helm chart's version to 0.34.1