### PR TITLE
Provide Event Streams token to API and Engine Controller

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -132,7 +132,7 @@ spec:
         - name: GALASA_EVENT_STREAMS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{- if .Values.eventStreamsSecretName }}{{ .Values.eventStreamsSecretName }}{{- else }}{{ .Release.Name }}-event-streams-token{{- end }}
+              name: event-streams-token
               key: GALASA_EVENT_STREAMS_TOKEN
         ports:
         - containerPort: 9010

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - name: GALASA_EVENT_STREAMS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{- if .Values.eventStreamsSecretName }}{{ .Values.eventStreamsSecretName }}{{- else }}{{ .Release.Name }}-event-streams-token{{- end }}
+              name: event-streams-token
               key: GALASA_EVENT_STREAMS_TOKEN
         ports:
         - containerPort: 9010

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -3,9 +3,11 @@
 
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace .Values.eventStreamsSecretName) }}
 
+# The Secret name was set in values but the Secret does not exist
 {{- if not $existingSecret }}
 
-{{- $eventStreamsSecretName := (printf "%s-%s" .Release.Name "event-streams-token") }}
+# The Secret must be called this to match the API/Engine Controller deployment spec
+{{- $eventStreamsSecretName := "event-streams-token" }}
 {{- $token := randAlphaNum 44 }}
 
 apiVersion: v1
@@ -21,7 +23,8 @@ stringData:
 # eventStreamsSecretName not set in values.yaml so generate a name and a Secret
 {{- else }}
 
-{{- $eventStreamsSecretName := (printf "%s-%s" .Release.Name "event-streams-token") }}
+# The Secret must be called this to match the API/Engine Controller deployment spec
+{{- $eventStreamsSecretName := "event-streams-token" }}
 {{- $token := randAlphaNum 44 }}
 
 apiVersion: v1


### PR DESCRIPTION
The use of "if" statements is not supported in the context of the API and Engine Controller's Deployment specs, so the event streams secret must have a set name. I have amended this in the event-streams-secret.yaml to match also.