### PR TITLE
Iss1935 - Disabling push trigger for helm workflow for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,22 +1,23 @@
-name: Trigger Helm workflow in automation repository
+name: Trigger Helm workflow in Automation repository
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
   
 env:
   NAMESPACE: galasa-dev
 
 jobs:
-    trigger-workflow:
-        name: trigger helm workflow
-        runs-on: ubuntu-latest
-        permissions: write-all
+  trigger-workflow:
+    name: Trigger Helm workflow
+    runs-on: ubuntu-latest
+    permissions: write-all
 
-        steps:
-        - name: Triggering workflow using Github API call
-          run: |
-           gh workflow run build-helm.yaml --repo https://github.com/${{env.NAMESPACE}}/automation
-          env:
-            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+    steps:
+    - name: Trigger Helm workflow using GitHub CLI call
+      run: |
+        gh workflow run build-helm.yaml --repo https://github.com/${{ env.NAMESPACE }}/automation
+      env:
+        GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Why?

Issue https://github.com/galasa-dev/projectmanagement/issues/1935 has included creating a trigger from pushes to main in this repository, essentially changes to the Helm chart, to start the Helm workflow which lives in automation.

I am disabling the trigger from pushes to main for now so that we don't uninstall/install the Helm chart multiple times with the GH workflow and the Tekton workflow, which could cause issues. I'll reenable the trigger when we move fully to GH Actions.

Added a trigger for workflow_dispatch so we can still test manually.