### PR TITLE
Remove duplicate comment within yaml if that causes Helm Upgrade failure

### DIFF
--- a/charts/ecosystem/templates/couchdb-secret.yaml
+++ b/charts/ecosystem/templates/couchdb-secret.yaml
@@ -5,7 +5,7 @@
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $couchdbSecretName) }}
 {{- if $existingSecret }}
 {{- $user = printf (index $existingSecret.data "COUCHDB_USER") | b64dec }}
-{{- $password = printf (index $existingSecret.data "COUCHDB_PASSWORD") | b64dec }} #Not a secret but logic for a kube secret #pragma: allowlist secret 
+{{- $password = printf (index $existingSecret.data "COUCHDB_PASSWORD") | b64dec }}
 {{- end -}}
 
 
@@ -16,5 +16,5 @@ metadata:
 type: Opaque
 stringData:
   COUCHDB_USER: "{{ $user }}"
-  COUCHDB_PASSWORD: "{{ $password }}" #Not a secret but logic for a kube secret #pragma: allowlist secret 
+  COUCHDB_PASSWORD: "{{ $password }}" #Not a secret but logic for a kube secret #pragma: allowlist secret
   GALASA_RAS_TOKEN: "{{ printf "%s:%s" $user $password | b64enc }}"


### PR DESCRIPTION
The couchdb-secret Helm template in the Ecosystem templates folder had a comment inside an "if" yaml block that was causing helm upgrade to fail with this error:

```
Error: UPGRADE FAILED: error validating "": error validating data: apiVersion not set
```

I've removed the comment as it is duplicated in the file anyway (may have originally been a copying error).
