### PR TITLE
Add encryption keys secret to Galasa service

### DIFF
--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -17,3 +17,24 @@
 {{- define "ecosystem.host.url" -}}
   {{- printf "%s://%s" (include "ecosystem.host.scheme" .) (.Values.externalHostname) }}
 {{- end -}}
+
+{{/*
+  Returns the location of the encryption keys file where it will be mounted in a pod
+*/}}
+{{- define "ecosystem.encryption.keys.path" -}}
+  {{- print "/galasa/encryption/encryption-keys.yaml" }}
+{{- end -}}
+
+{{/*
+  Returns the directory path where the encryption keys file will be mounted under
+*/}}
+{{- define "ecosystem.encryption.keys.directory" -}}
+  {{- dir (include "ecosystem.encryption.keys.path" .) }}
+{{- end -}}
+
+{{/*
+  Returns the name of the secret that stores encryption keys
+*/}}
+{{- define "ecosystem.encryption.keys.secret.name" -}}
+  {{- empty .Values.encryption.keysSecretName | ternary (printf "%s-encryption-secret" .Release.Name) (.Values.encryption.keysSecretName) }}
+{{- end -}}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -134,6 +134,8 @@ spec:
             secretKeyRef:
               name: event-streams-token
               key: GALASA_EVENT_STREAMS_TOKEN
+        - name: GALASA_ENCRYPTION_KEYS_PATH
+          value: {{ include "ecosystem.encryption.keys.path" . }}
         ports:
         - containerPort: 9010
           name: metrics
@@ -162,6 +164,9 @@ spec:
           subPath: dev.galasa.testcatalog.cfg
         - name: data
           mountPath: /galasa/testcatalog
+        - name: encryption-keys
+          mountPath: {{ include "ecosystem.encryption.keys.directory" . }}
+          readOnly: true
       volumes:
       - name: bootstrap
         configMap:
@@ -172,3 +177,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-pvc-testcatalog
+      - name: encryption-keys
+        secret:
+          secretName: {{ include "ecosystem.encryption.keys.secret.name" . }}

--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -35,3 +35,7 @@ data:
 #  engine_memory_limit: "300"
   run_poll: "5"
   run_poll_recheck: "2"
+#
+# The name of the Kubernetes Secret that stores the encryption-related keys,
+# so that test pods can decrypt credentials where necessary
+  encryption_keys_secret_name: {{ include "ecosystem.encryption.keys.secret.name" . }}

--- a/charts/ecosystem/templates/couchdb-secret.yaml
+++ b/charts/ecosystem/templates/couchdb-secret.yaml
@@ -1,3 +1,8 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
 {{- $user := randAlphaNum 32 }}
 {{- $password := randAlphaNum 32 }}
 {{- $couchdbSecretName := (printf "%s-couchdb-secret" .Release.Name )}}
@@ -6,9 +11,7 @@
 {{- if $existingSecret }}
 {{- $user = printf (index $existingSecret.data "COUCHDB_USER") | b64dec }}
 {{- $password = printf (index $existingSecret.data "COUCHDB_PASSWORD") | b64dec }}
-{{- end -}}
-
-
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/ecosystem/templates/encryption-keys-secret.yaml
+++ b/charts/ecosystem/templates/encryption-keys-secret.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- if not .Values.encryption.keysSecretName }}
+{{- $encryptionSecretName := (include "ecosystem.encryption.keys.secret.name" .)}}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $encryptionSecretName) }}
+{{- if not $existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $encryptionSecretName }}
+  annotations:
+    helm.sh/resource-policy: "keep"
+type: Opaque
+stringData:
+  encryption-keys.yaml: |-
+    encryptionKey: {{ randAlphaNum 32 | b64enc }}
+    fallbackDecryptionKeys: []
+{{- end }}
+{{- end }}

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -83,6 +83,8 @@ spec:
             secretKeyRef:
               name: event-streams-token
               key: GALASA_EVENT_STREAMS_TOKEN
+        - name: GALASA_ENCRYPTION_KEYS_PATH
+          value: {{ include "ecosystem.encryption.keys.path" . }}
         ports:
         - containerPort: 9010
           name: metrics
@@ -100,3 +102,11 @@ spec:
             port: 9011
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        - name: encryption-keys
+          mountPath: {{ include "ecosystem.encryption.keys.directory" . }}
+          readOnly: true
+      volumes:
+      - name: encryption-keys
+        secret:
+          secretName: {{ include "ecosystem.encryption.keys.secret.name" . }}

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -1,3 +1,8 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
 # eventStreamsSecretName set in values.yaml so use that Secret name for the lookup
 {{- if .Values.eventStreamsSecretName }}
 

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -88,6 +88,21 @@ dexImage: "ghcr.io/dexidp/dex:v2.38.0"
 kubectlImage: "bitnami/kubectl:1.28"
 #
 #
+# Values related to the encryption of Galasa secrets
+#
+encryption:
+  # Optional. The name of an existing Kubernetes Secret that contains
+  # a set of encryption keys in the following YAML format:
+  #
+  # encryption-keys.yaml: |
+  #   encryptionKey: <current-encryption-key>
+  #   fallbackDecryptionKeys:
+  #   - <fallback-key-1>
+  #   - <fallback-key-2>
+  #
+  keysSecretName: ""
+#
+#
 # A list of origins that are allowed to receive responses from the Galasa API server.
 # To limit the origins to a set of domains, you can use a wildcard (*) value.
 #


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1467

## Changes
- Added encryption keys secret into the ecosystem helm chart so that helm installs will now automatically generate an encryption key for the installed Galasa service to use
  - Loaded the encryption keys secret into deployments that require it (API server, engine controller)
  - Added missing copyright statements to couchdb and event streams secrets