### PR TITLE
GALASA_SERVICE_NAME could have spaces inside, so needs quotation marks for valid yaml syntax.

### DIFF
--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -53,7 +53,7 @@ spec:
         - name: GALASA_WEBUI_CLIENT_ID
           value: galasa-webui
         - name: GALASA_SERVICE_NAME
-          value: {{ .Values.galasaServiceName }}
+          value: "{{ .Values.galasaServiceName }}"
         {{- if .Values.ingress.caCertSecretName }}
         - name: NODE_EXTRA_CA_CERTS
           value: /etc/ssl/certs/cacerts/cacerts.pem


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
The title on the Galasa Service is always showing the same thing.
Sometimes it's intermittent whether it shows "Galasa Prod 1" or "Galasa Service"

I noted that the yaml used does not bracket the name in the helm chart with double-quotes/single-quotes, so isn't forming valid yaml. This may be the reason for it ?

Correct the yaml template render from helm and see if that solves it.