### PR TITLE
Add node affinity and toleration conditions and doc

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -35,8 +35,12 @@ data:
 #  engine_memory_limit: "300"
   run_poll: "5"
   run_poll_recheck: "2"
-  galasa_node_preferred_affinity: "{{ .Values.k8s_node_preferred_affinity }}"
-  galasa_node_tolerations: "{{ .Values.k8s_node_tolerations }}"
+#
+# Label of k8s node that Galasa test pods should be scheduled on preferrentially
+  galasa_node_preferred_affinity: "{{ .Values.k8sNodePreferredAffinity }}"
+#
+# List of node toleration conditions
+  galasa_node_tolerations: "{{ .Values.k8sNodeTolerations }}"
 
 
 #

--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -35,6 +35,10 @@ data:
 #  engine_memory_limit: "300"
   run_poll: "5"
   run_poll_recheck: "2"
+  galasa_node_preferred_affinity: "{{ .Values.k8s_node_preferred_affinity }}"
+  galasa_node_tolerations: "{{ .Values.k8s_node_tolerations }}"
+
+
 #
 # The name of the Kubernetes Secret that stores the encryption-related keys,
 # so that test pods can decrypt credentials where necessary

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -55,7 +55,7 @@ galasaWebUiImage: "galasa-ui"
 #
 # Example value: "galasa-engines"
 #
-k8s_node_preferred_affinity: ""
+k8sNodePreferredAffinity: ""
 #
 #
 #
@@ -73,7 +73,7 @@ k8s_node_preferred_affinity: ""
 # "NoSchedule" taint should be tolerated, resulting in the Galasa test pods
 # having exclusive access to run on this node.
 #
-k8s_node_tolerations: ""
+k8sNodeTolerations: ""
 #
 #
 # The pull policy to be used for the Galasa images, only useful for Galasa development purposes

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -20,7 +20,7 @@ galasaVersion: "0.38.0"
 # Name of the galasa service which will be shown as the title of the web user interface page.
 # Any bookmarks taken by users in their browsers will also receive this name.
 # Making this name distict helps users identify which Galasa service they are using.
-# If they are all called the same thing, users with access to multiple systems may find that 
+# If they are all called the same thing, users with access to multiple systems may find that
 # confusing.
 # It is RECOMMENDED that this value is changed to be unique,
 # For example: Galasa Service XYZ
@@ -46,6 +46,34 @@ maxEngines: "10"
 # The name of the Docker image that launches Galasa's web UI
 #
 galasaWebUiImage: "galasa-ui"
+#
+#
+#
+# Optional. The label of a Kubernetes node that the engine controller should
+# have an affinity for. If possible, the engine controller will schedule
+# Galasa runs on this node.
+#
+# Example value: "galasa-engines"
+#
+k8s_node_preferred_affinity: ""
+#
+#
+#
+# Optional. The definition of a Kubernetes node taint toleration behaviour.
+# You may wish to prevent other workloads from being scheduled on your dedicated
+# Galasa k8s nodes. This can be achieved by tainting the Galasa k8s nodes. If this
+# has been done, you will need to define a toleration for your Galasa pods so that
+# they can schedule on the tainted nodes.
+#
+# The value should define a node label, an operator and a condition.
+#
+# Example value: "galasa-engines=Exists:NoSchedule"
+#
+# In the above example, any node which has the label "galasa-engines" with a
+# "NoSchedule" taint should be tolerated, resulting in the Galasa test pods
+# having exclusive access to run on this node.
+#
+k8s_node_tolerations: ""
 #
 #
 # The pull policy to be used for the Galasa images, only useful for Galasa development purposes


### PR DESCRIPTION
Following on from discussions here https://github.com/galasa-dev/galasa/pull/45 I am raising this PR to contribute the ability to set the galasa_node_preferred_affinity and galasa_node_tolerations parameters via the Values.yaml file for deploying the Galasa ecosystem, and to include documentation on their usage.