### PR TITLE
Update token used for Helm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           skip_existing: true # Skip package upload if release/tag already exists
           skip_upload: true # Skips upload to index.yaml
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GALASA_TEAM_REPO_SCOPE_TOKEN }}"
 
       - name: Run chart-releaser - release
         if: (github.ref == 'refs/heads/release')
@@ -40,4 +40,4 @@ jobs:
         with:
           skip_existing: true # Skip package upload if release/tag already exists
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GALASA_TEAM_REPO_SCOPE_TOKEN }}"


### PR DESCRIPTION
## Why?

Latest actions workflow for release.yaml said the default `GITHUB_TOKEN` was forbidden to create a release so I have created a new token with the sufficient permissions and substituted this into the workflow.