### PR TITLE
Add values to configure API server ingress annotations and replicas with optional autoscaling

### DIFF
--- a/charts/ecosystem/templates/api-bootstrap-ingress.yaml
+++ b/charts/ecosystem/templates/api-bootstrap-ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.apiServer.ingressAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /bootstrap/external
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}

--- a/charts/ecosystem/templates/api-ingress.yaml
+++ b/charts/ecosystem/templates/api-ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.apiServer.ingressAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}

--- a/charts/ecosystem/templates/api-pod-autoscaler.yaml
+++ b/charts/ecosystem/templates/api-pod-autoscaler.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+{{- if .Values.apiServer.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-api-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-api
+  minReplicas: {{ .Values.apiServer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.apiServer.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.apiServer.autoscaling.targetMemoryPercentageUsed }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.apiServer.autoscaling.targetMemoryPercentageUsed }}
+    {{- end }}
+    {{- if .Values.apiServer.autoscaling.targetCPUPercentageUsed }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.apiServer.autoscaling.targetCPUPercentageUsed }}
+    {{- end }}
+{{- end }}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -163,6 +163,9 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{- with .Values.apiServer.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: bootstrap
           mountPath: /bootstrap.properties

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-api
 spec:
-  replicas: {{ .Values.api.replicaCount }}
+  replicas: {{ .Values.apiServer.replicaCount }}
   strategy:
     type: Recreate
   selector:
@@ -118,15 +118,15 @@ spec:
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
         - name: GALASA_GLOBAL_REQUEST_CAPACITY
-          value: {{ .Values.api.globalRequestCapacity }}
+          value: {{ .Values.apiServer.globalRequestCapacity }}
         - name: GALASA_GLOBAL_RATE_LIMIT
-          value: {{ .Values.api.globalRateLimit }}
+          value: {{ .Values.apiServer.globalRateLimit }}
         - name: GALASA_IP_REQUEST_CAPACITY
-          value: {{ .Values.api.ipRequestCapacity }}
+          value: {{ .Values.apiServer.ipRequestCapacity }}
         - name: GALASA_IP_RATE_LIMIT
-          value: {{ .Values.api.ipRateLimit }}
+          value: {{ .Values.apiServer.ipRateLimit }}
         - name: GALASA_ALLOWED_ORIGINS
-          value: {{ join "," .Values.api.allowedOrigins | quote }}
+          value: {{ join "," .Values.apiServer.allowedOrigins | quote }}
         - name: GALASA_RAS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: {{ .Release.Name }}-api
 spec:
-  replicas: 1
+  replicas: {{ .Values.api.replicaCount }}
   strategy:
     type: Recreate
   selector:
@@ -117,8 +117,16 @@ spec:
           value: {{ include "ecosystem.host.url" . }}/api
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
+        - name: GALASA_GLOBAL_REQUEST_CAPACITY
+          value: {{ .Values.api.globalRequestCapacity }}
+        - name: GALASA_GLOBAL_RATE_LIMIT
+          value: {{ .Values.api.globalRateLimit }}
+        - name: GALASA_IP_REQUEST_CAPACITY
+          value: {{ .Values.api.ipRequestCapacity }}
+        - name: GALASA_IP_RATE_LIMIT
+          value: {{ .Values.api.ipRateLimit }}
         - name: GALASA_ALLOWED_ORIGINS
-          value: {{ join "," .Values.allowedOrigins | quote }}
+          value: {{ join "," .Values.api.allowedOrigins | quote }}
         - name: GALASA_RAS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -117,14 +117,6 @@ spec:
           value: {{ include "ecosystem.host.url" . }}/api
         - name: GALASA_USERNAME_CLAIMS
           value: {{ join "," .Values.dex.usernameClaims | quote }}
-        - name: GALASA_GLOBAL_REQUEST_CAPACITY
-          value: {{ .Values.apiServer.globalRequestCapacity }}
-        - name: GALASA_GLOBAL_RATE_LIMIT
-          value: {{ .Values.apiServer.globalRateLimit }}
-        - name: GALASA_IP_REQUEST_CAPACITY
-          value: {{ .Values.apiServer.ipRequestCapacity }}
-        - name: GALASA_IP_RATE_LIMIT
-          value: {{ .Values.apiServer.ipRateLimit }}
         - name: GALASA_ALLOWED_ORIGINS
           value: {{ join "," .Values.apiServer.allowedOrigins | quote }}
         - name: GALASA_RAS_TOKEN

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -162,7 +162,7 @@ apiServer:
   autoscaling:
     #
     # Enables or disables autoscaling
-    enabled: true
+    enabled: false
     #
     # The minimum number of API server replicas that should be deployed
     minReplicas: 1
@@ -182,11 +182,10 @@ apiServer:
   #
   #
   # The Kubernetes annotations to apply to the Galasa API server's ingress resource alongside the global annotations provided via the `ingress.annotations` value.
-  # By default, a rate limit of 1000 requests from a given IP per second is applied to the API server's ingress, using the nginx IngressClass.
+  # By default, a rate limit of 1000 requests from a given IP per second is applied to the API server's ingress, using the nginx ingress controller.
   #
   ingressAnnotations:
     nginx.ingress.kubernetes.io/limit-rps: "1000"
-  #
   #
   #
   # A list of origins that are allowed to receive responses from the Galasa API server.
@@ -201,8 +200,7 @@ apiServer:
   allowedOrigins:
     - "*"
 #
-#
-# Values to configure all ingresses
+# Values to configure global settings applied to all ingresses
 # Note: The externalHostname value must be a valid DNS name for ingress to be used.
 #
 ingress:

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -133,7 +133,7 @@ encryption:
 #
 # Values to configure the API server
 #
-api:
+apiServer:
   #
   #
   # The number of API server replicas to deploy

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -138,27 +138,15 @@ apiServer:
   #
   # The number of API server replicas to deploy
   #
-  replicaCount: "1"
+  replicaCount: "2"
   #
   #
-  # The maximum number of requests that can be sent to the API server after a refreshed rate limit
+  # The Kubernetes annotations to apply to the Galasa API server's ingress resource alongside the global annotations provided via the `ingress.annotations` value.
+  # By default, a rate limit of 1000 requests from a given IP per second is applied to the API server's ingress, using the nginx IngressClass.
   #
-  globalRequestCapacity: "100000"
+  ingressAnnotations:
+    nginx.ingress.kubernetes.io/limit-rps: "1000"
   #
-  #
-  # The rate at which requests can be sent to the API server per second
-  #
-  globalRateLimit: "100000"
-  #
-  #
-  # The maximum number of requests that can be sent to the API server after a refreshed rate limit per IP address
-  #
-  ipRequestCapacity: "50000"
-  #
-  #
-  # The rate at which requests can be sent to the API server per second, per IP address
-  #
-  ipRateLimit: "50000"
   #
   #
   # A list of origins that are allowed to receive responses from the Galasa API server.
@@ -174,7 +162,7 @@ apiServer:
     - "*"
 #
 #
-# Values to enable and configure the use of ingress
+# Values to configure all ingresses
 # Note: The externalHostname value must be a valid DNS name for ingress to be used.
 #
 ingress:
@@ -191,7 +179,7 @@ ingress:
   # Optional - The name of the Secret containing root and intermediate CA certificates in a single .pem file.
   caCertSecretName: ""
 
-  # Annotations to be added to ingresses. For example:
+  # Annotations to be added to all ingresses. For example:
   # annotations:
   #   nginx.ingress.kubernetes.io/proxy-body-size: "0"
   #   nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -131,17 +131,47 @@ encryption:
   keysSecretName: ""
 #
 #
-# A list of origins that are allowed to receive responses from the Galasa API server.
-# To limit the origins to a set of domains, you can use a wildcard (*) value.
+# Values to configure the API server
 #
-# For example, to allow all subdomains of example.com, you can use the following value:
-# allowedOrigins:
-#   - "*.example.com"
-#
-# By default, all origins are allowed.
-#
-allowedOrigins:
-  - "*"
+api:
+  #
+  #
+  # The number of API server replicas to deploy
+  #
+  replicaCount: "1"
+  #
+  #
+  # The maximum number of requests that can be sent to the API server after a refreshed rate limit
+  #
+  globalRequestCapacity: "100000"
+  #
+  #
+  # The rate at which requests can be sent to the API server per second
+  #
+  globalRateLimit: "100000"
+  #
+  #
+  # The maximum number of requests that can be sent to the API server after a refreshed rate limit per IP address
+  #
+  ipRequestCapacity: "50000"
+  #
+  #
+  # The rate at which requests can be sent to the API server per second, per IP address
+  #
+  ipRateLimit: "50000"
+  #
+  #
+  # A list of origins that are allowed to receive responses from the Galasa API server.
+  # To limit the origins to a set of domains, you can use a wildcard (*) value.
+  #
+  # For example, to allow all subdomains of example.com, you can use the following value:
+  # allowedOrigins:
+  #   - "*.example.com"
+  #
+  # By default, all origins are allowed.
+  #
+  allowedOrigins:
+    - "*"
 #
 #
 # Values to enable and configure the use of ingress

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -136,9 +136,49 @@ encryption:
 apiServer:
   #
   #
-  # The number of API server replicas to deploy
+  # The number of API server replicas to deploy. This value is overridden when autoscaling is enabled.
   #
-  replicaCount: "2"
+  replicaCount: 2
+  #
+  #
+  # The requests and limits to apply to resources, like CPU and memory, that the API server container consumes.
+  # See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for details on resource management in Kubernetes Pods.
+  #
+  # For example, to assign 2 CPU cores and 512MB of memory to the API server, with a limit of up to 3 CPU cores and 1024MB of memory:
+  # resources:
+  #   requests:
+  #     cpu: "2"
+  #     memory: "512Mi"
+  #   limits:
+  #     cpu: "3"
+  #     memory: "1024Mi"
+  #
+  resources: {}
+  #
+  #
+  # Values to configure autoscaling for the API server. Important: Resource requests must be defined via the `resources` value in order
+  # for autoscaling to work properly.
+  #
+  autoscaling:
+    #
+    # Enables or disables autoscaling
+    enabled: true
+    #
+    # The minimum number of API server replicas that should be deployed
+    minReplicas: 1
+    #
+    # The maximum number of API server replicas that should be deployed
+    maxReplicas: 10
+    #
+    # The target percentage of CPU utilization to consider when autoscaling.
+    # For example: `targetCPU: "50"` indicates that the autoscaler may increase the number of replicas when CPU utilization
+    # exceeds 50%. Similarly, when CPU utilization drops below 50%, the autoscaler may decrease the number of replicas.
+    targetCPUPercentageUsed: "50"
+    #
+    # The target percentage of memory utilization to consider when autoscaling.
+    # For example: `targetMemory: "50"` indicates that the autoscaler may increase the number of replicas when memory utilization
+    # exceeds 50%. Similarly, when memory utilization drops below 50%, the autoscaler may decrease the number of replicas.
+    targetMemoryPercentageUsed: "50"
   #
   #
   # The Kubernetes annotations to apply to the Galasa API server's ingress resource alongside the global annotations provided via the `ingress.annotations` value.


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2072

## Changes
- Added values to configure the API server's ingress annotations and the number of replicas to deploy
  - Added an `apiServer` value to group related API server values together
  - Set default API server replicas to 2
  - Set default API server ingress annotation to allow 1000 requests per second from each IP (see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rate-limiting)
- Added a HorizontalPodAutoscaler resource for the API server so that API server replicas can be scaled based on given parameters
  - Added values to configure the autoscaler for the API server, including `minReplicas` and `maxReplicas`
- Added a `resources` value to allow users to configure the API server's resource minimum usage and set upper limits (this is required for autoscaling to work)