### PR TITLE
Iss2085 - Skip workflow if a fork is running it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   trigger-workflow:
+    # Skip this for forks.
+    if: ${{ github.repository_owner == 'galasa-dev' }}
     name: Trigger Helm workflow
     runs-on: ubuntu-latest
     permissions: write-all
@@ -24,10 +26,11 @@ jobs:
         GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
 
   report-failure:
+    # Skip this for forks.
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: trigger-workflow
-    if: failure()
 
     steps:
       - name: Report failure in workflow to Slack


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2085

Forks pushing to their main branch shouldn't run this workflow as it triggers another workflow that attempts to uninstall/install the Galasa Helm chart. It will fail anyway, but this should just quietly skip for forks.