### PR TITLE
default user role config passed to api server pod

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -109,6 +109,8 @@ spec:
           value: couchdb:http://{{ .Release.Name }}-couchdb:5984
         - name: GALASA_CREDENTIALS_STORE
           value: etcd:http://{{ .Release.Name }}-etcd:2379
+        - name: GALASA_DEFAULT_USER_ROLE
+          value: {{ .Values.galasaDefaultUserRole }}
         - name: GALASA_DEX_ISSUER
           value: {{ .Values.dex.config.issuer }}
         - name: GALASA_DEX_GRPC_HOSTNAME

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -119,7 +119,7 @@ kubectlImage: "bitnami/kubectl:1.28"
 # New users logging into the system get a user record created and that user is assigned a role
 # by default. It should be the name of one of the roles on the system.
 # Suggested values are:
-#   "deactivated" - After initial logon, an administrator will need to set their most apropriate role 
+#   "deactivated" - After initial logon, an administrator will need to set their most appropriate role 
 #                   before this new user can access any function within the Galasa service.
 #   "tester"      - After initial logon, the user is classified as a tester, so can launch tests and 
 #                   see test results, but cannot administer the system.

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -115,6 +115,19 @@ couchdbImage: "couchdb:3.3.3"
 dexImage: "ghcr.io/dexidp/dex:v2.38.0"
 kubectlImage: "bitnami/kubectl:1.28"
 #
+#  
+# New users logging into the system get a user record created and that user is assigned a role
+# by default. It should be the name of one of the roles on the system.
+# Suggested values are:
+#   "deactivated" - After initial logon, an administrator will need to set their most apropriate role 
+#                   before this new user can access any function within the Galasa service.
+#   "tester"      - After initial logon, the user is classified as a tester, so can launch tests and 
+#                   see test results, but cannot administer the system.
+#   "admin"       - A user with access to all the functionality provided by Galasa.
+#                   We recommend only using this setting if you want every user to be an administrator
+#                   (unlikely).
+galasaDefaultUserRole: "tester"
+#
 #
 # Values related to the encryption of Galasa secrets
 #


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See [Minimal Admin/Non-admin RBAC #2071](https://github.com/galasa-dev/projectmanagement/issues/2071)

- Pass a configuration parameter to the API server, allowing it to be settable when the helm chart is used.