### PR TITLE
mcobbett owner login ids

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -111,6 +111,8 @@ spec:
           value: etcd:http://{{ .Release.Name }}-etcd:2379
         - name: GALASA_DEFAULT_USER_ROLE
           value: {{ .Values.galasaDefaultUserRole }}
+        - name: GALASA_OWNER_LOGIN_IDS
+          value: {{ .Values.galasaOwnersLoginIds }}
         - name: GALASA_DEX_ISSUER
           value: {{ .Values.dex.config.issuer }}
         - name: GALASA_DEX_GRPC_HOSTNAME

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -132,7 +132,10 @@ galasaDefaultUserRole: "tester"
 # The list of login ids of the Galasa service owner(s), comma-separated.
 # If a user login id appears in this list, the user will appear to have the 'owner' role, rather than 
 # their normal role.
-# Roles of owner user records cannot be changed. The users nominated here will always have a role of 'owner'.
+#
+# Roles of owner user records cannot be changed. Without changing the configuration at the Kubernetes level.
+# 
+# The users nominated here will always have a role of 'owner'.
 #
 # If the Galasa service owners leave the organisation, or are otherwise unable to administer the system any longer,
 # someone with access to kubernetes can change this value and the user specified will then appear to have the role

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -129,6 +129,20 @@ kubectlImage: "bitnami/kubectl:1.28"
 galasaDefaultUserRole: "tester"
 #
 #
+# The list of login ids of the Galasa service owner(s), comma-separated.
+# If a user login id appears in this list, the user will appear to have the 'owner' role, rather than 
+# their normal role.
+# Roles of owner user records cannot be changed. The users nominated here will always have a role of 'owner'.
+#
+# If the Galasa service owners leave the organisation, or are otherwise unable to administer the system any longer,
+# someone with access to kubernetes can change this value and the user specified will then appear to have the role
+# of owner.
+#
+# Multiple owners can be specified. eg: "user1, user2". All users mentioned will have the 'owner' role until they are 
+# removed from the list.
+galasaOwnersLoginIds: ""
+#
+#
 # Values related to the encryption of Galasa secrets
 #
 encryption:


### PR DESCRIPTION
# Why ?
[RBAC : prevent admin lock-out #2106](https://github.com/galasa-dev/projectmanagement/issues/2106)

- **helm sets a list of galasa service owners using GALASA_OWNER_LOGIN_IDS**
