### PR TITLE
Add custom resource monitor deployment and pass in monitor config into the galasa boot.jar

### DIFF
--- a/charts/ecosystem/rbac.yaml
+++ b/charts/ecosystem/rbac.yaml
@@ -24,7 +24,7 @@ rules:
   verbs: ["get","update"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["get","patch","list","watch"]
+  verbs: ["get","patch","list","watch","update"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","create","delete"]

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -99,6 +99,8 @@ spec:
         - --bootstrap
         - file:/bootstrap.properties
         env:
+        # The Kubernetes namespace that the Galasa service is running within is passed into the API server
+        # so that the API server can query Kubernetes for monitor deployments in the /monitors REST APIs
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -99,6 +99,10 @@ spec:
         - --bootstrap
         - file:/bootstrap.properties
         env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: GALASA_CONFIG_STORE
           value: etcd:{{ include "cps.url" . }}
         - name: GALASA_DYNAMICSTATUS_STORE

--- a/charts/ecosystem/templates/custom-resource-monitor-service-internal.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor-service-internal.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-custom-resource-monitor-internal
+  labels:
+    app: {{ .Release.Name }}-custom-resource-monitor-internal
+spec:
+  ports:
+  - port: 9010
+    name: metrics
+  - port: 9011
+    name: health
+  selector:
+    app: {{ .Release.Name }}-custom-resource-monitor

--- a/charts/ecosystem/templates/custom-resource-monitor.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor.yaml
@@ -8,6 +8,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-custom-resource-monitor
   labels:
+    galasa-monitor: custom
     app: {{ .Release.Name }}-custom-resource-monitor
 spec:
   replicas: 0

--- a/charts/ecosystem/templates/custom-resource-monitor.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor.yaml
@@ -3,25 +3,24 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-resource-monitor
+  name: {{ .Release.Name }}-custom-resource-monitor
   labels:
-    app: {{ .Release.Name }}-resource-monitor
+    app: {{ .Release.Name }}-custom-resource-monitor
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-resource-monitor
+      app: {{ .Release.Name }}-custom-resource-monitor
   template:
     metadata:
-      name: {{ .Release.Name }}-resource-monitor
+      name: {{ .Release.Name }}-custom-resource-monitor
       labels:
-        app: {{ .Release.Name }}-resource-monitor
+        app: {{ .Release.Name }}-custom-resource-monitor
     spec:
       serviceAccountName: galasa
       nodeSelector:
@@ -72,8 +71,12 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        - name: GALASA_CLEANUP_MONITOR_STREAM
+          value: {{ .Values.cleanupMonitor.stream }}
         - name: GALASA_MONITOR_INCLUDES_REGEXES
-          value: "dev.galasa.*"
+          value: {{ join "," .Values.cleanupMonitor.includes }}
+        - name: GALASA_MONITOR_EXCLUDES_REGEXES
+          value: {{ join "," .Values.cleanupMonitor.excludes }}
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/custom-resource-monitor.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor.yaml
@@ -72,12 +72,14 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        {{- if .Values.cleanupMonitor.stream }}
         - name: GALASA_CLEANUP_MONITOR_STREAM
-          value: {{ .Values.cleanupMonitor.stream }}
+          value: "{{ .Values.cleanupMonitor.stream }}"
+        {{- end }}
         - name: GALASA_MONITOR_INCLUDES_REGEXES
-          value: {{ join "," .Values.cleanupMonitor.includes }}
+          value: "{{ join "," .Values.cleanupMonitor.includes }}"
         - name: GALASA_MONITOR_EXCLUDES_REGEXES
-          value: {{ join "," .Values.cleanupMonitor.excludes }}
+          value: "{{ join "," .Values.cleanupMonitor.excludes }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/custom-resource-monitor.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor.yaml
@@ -73,12 +73,12 @@ spec:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
         {{- if .Values.cleanupMonitor.stream }}
-        - name: GALASA_CLEANUP_MONITOR_STREAM
+        - name: GALASA_MONITOR_STREAM
           value: "{{ .Values.cleanupMonitor.stream }}"
         {{- end }}
-        - name: GALASA_MONITOR_INCLUDES_REGEXES
+        - name: GALASA_MONITOR_INCLUDES_GLOB_PATTERNS
           value: "{{ join "," .Values.cleanupMonitor.includes }}"
-        - name: GALASA_MONITOR_EXCLUDES_REGEXES
+        - name: GALASA_MONITOR_EXCLUDES_GLOB_PATTERNS
           value: "{{ join "," .Values.cleanupMonitor.excludes }}"
         ports:
         - containerPort: 9010

--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -25,7 +25,7 @@ rules:
   verbs: ["get","update"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["get","patch","list","watch"]
+  verbs: ["get","patch","list","watch","update"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get","list","create","delete"]

--- a/charts/ecosystem/templates/resource-monitor-service-internal.yaml
+++ b/charts/ecosystem/templates/resource-monitor-service-internal.yaml
@@ -7,9 +7,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-resource-monitor-external
+  name: {{ .Release.Name }}-resource-monitor-internal
   labels:
-    app: {{ .Release.Name }}-resource-monitor-external
+    app: {{ .Release.Name }}-resource-monitor-internal
 spec:
   ports:
   - port: 9010

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -73,7 +73,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
-        - name: GALASA_MONITOR_INCLUDES_REGEXES
+        - name: GALASA_MONITOR_INCLUDES_GLOB_PATTERNS
           value: "dev.galasa.*"
         ports:
         - containerPort: 9010

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -9,6 +9,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-resource-monitor
   labels:
+    galasa-monitor: system
     app: {{ .Release.Name }}-resource-monitor
 spec:
   replicas: 1

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -368,13 +368,13 @@ cpsUrl: http://RELEASE_NAME-etcd:2379
 #
 cleanupMonitor:
   #
-  # The name of the stream in which the custom resource cleanup bundles can be located.
+  # The name of the stream in which custom resource cleanup providers can be located.
   stream: ""
   #
-  # A list of regex patterns to be used in identifying which bundles to load as part of
-  # the custom resource cleanup monitor.
+  # A list of regex patterns to be used in identifying which resource cleanup providers
+  # to load as part of the custom resource cleanup monitor.
   includes: []
   #
-  # A list of regex patterns to be used in identifying which bundles should not be loaded
-  # as part of the custom resource cleanup monitor.
+  # A list of regex patterns to be used in identifying which resource cleanup providers
+  # should not be loaded as part of the custom resource cleanup monitor.
   excludes: []

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -371,10 +371,30 @@ cleanupMonitor:
   # The name of the stream in which custom resource cleanup providers can be located.
   stream: ""
   #
-  # A list of regex patterns to be used in identifying which resource cleanup providers
+  # A list of glob patterns to be used in identifying which resource cleanup providers
   # to load as part of the custom resource cleanup monitor.
+  #
+  # Supported glob patterns include the following special characters: 
+  # '*' (wildcard) Matches zero or more characters
+  # '?' matches exactly one character
+  #
+  # For example, the pattern 'dev.galasa*' will match any monitor that includes 'dev.galasa' as its prefix,
+  # so a class like 'dev.galasa.core.CoreResourceMonitorClass' will be matched.
+  #
+  # A pattern like '*MyResourceMonitorClass' will match any monitor that ends with 'MyResourceMonitorClass',
+  # such as 'my.company.monitors.MyResourceMonitorClass'.
   includes: []
   #
-  # A list of regex patterns to be used in identifying which resource cleanup providers
+  # A list of glob patterns to be used in identifying which resource cleanup providers
   # should not be loaded as part of the custom resource cleanup monitor.
+  #
+  # Supported glob patterns include the following special characters: 
+  # '*' (wildcard) Matches zero or more characters
+  # '?' matches exactly one character
+  #
+  # For example, the pattern '*' will match any monitor, so a class like 'dev.galasa.core.CoreResourceMonitorClass'
+  # will be matched.
+  #
+  # A pattern like '*MyResourceMonitorClass' will match any monitor that ends with 'MyResourceMonitorClass',
+  # such as 'my.company.monitors.MyResourceMonitorClass'.
   excludes: []

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -360,3 +360,21 @@ eventStreamsSecretName: "event-streams-token"
 dssUrl: http://RELEASE_NAME-etcd:2379
 credsUrl: http://RELEASE_NAME-etcd:2379
 cpsUrl: http://RELEASE_NAME-etcd:2379
+#
+#
+# cleanupMonitor represents the values required to configure a custom resource cleanup
+# monitor for use by the Galasa service, so that resources provisioned by managers that
+# are not publicly available in the Galasa open source offering can be cleaned up.
+#
+cleanupMonitor:
+  #
+  # The name of the stream in which the custom resource cleanup bundles can be located.
+  stream: ""
+  #
+  # A list of regex patterns to be used in identifying which bundles to load as part of
+  # the custom resource cleanup monitor.
+  includes: []
+  #
+  # A list of regex patterns to be used in identifying which bundles should not be loaded
+  # as part of the custom resource cleanup monitor.
+  excludes: []


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2067

## Changes
- Added custom resource monitor deployment that is scaled to 0 replicas by default
- Added a new `cleanupMonitor` value to configure the resource cleanup providers that are loaded into the custom resource monitor
- Updated the existing system resource monitor deployment to only include resource cleanup providers in `dev.galasa.*` packages