### PR TITLE
Add includes and excludes values to system monitor deployment

### DIFF
--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -74,7 +74,9 @@ spec:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
         - name: GALASA_MONITOR_INCLUDES_GLOB_PATTERNS
-          value: "dev.galasa.*"
+          value: "{{ join "," .Values.resourceMonitor.includes }}"
+        - name: GALASA_MONITOR_EXCLUDES_GLOB_PATTERNS
+          value: "{{ join "," .Values.resourceMonitor.excludes }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -398,3 +398,37 @@ cleanupMonitor:
   # A pattern like '*MyResourceMonitorClass' will match any monitor that ends with 'MyResourceMonitorClass',
   # such as 'my.company.monitors.MyResourceMonitorClass'.
   excludes: []
+#
+#
+# resourceMonitor represents the values used to configure the system resource cleanup 
+# monitor used by the Galasa service. Only the monitors that are available in the
+# dev.galasa.uber.OBR bundle can be included and excluded. For custom monitors,
+# see the 'cleanupMonitor' values.
+#
+resourceMonitor:
+  #
+  # A list of glob patterns to be used in identifying which resource cleanup providers to load.
+  #
+  # Supported glob patterns include the following special characters: 
+  # '*' (wildcard) Matches zero or more characters
+  # '?' matches exactly one character
+  #
+  # For example, the pattern 'dev.galasa*' will match any provider that includes 'dev.galasa' as its prefix,
+  # so a class like 'dev.galasa.core.CoreResourceMonitorClass' will be matched.
+  #
+  # By default, all of the providers matching 'dev.galasa*' are included.
+  includes:
+    - 'dev.galasa*'
+  #
+  # A list of glob patterns to be used in identifying which resource cleanup providers
+  # should not be loaded.
+  #
+  # Supported glob patterns include the following special characters: 
+  # '*' (wildcard) Matches zero or more characters
+  # '?' matches exactly one character
+  #
+  # For example, the pattern '*' will match any monitor, so a class like 'dev.galasa.core.CoreResourceMonitorClass'
+  # will be matched.
+  #
+  # By default, no providers are excluded.
+  excludes: []


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2067

## Changes
- Parameterised the includes and excludes glob patterns for the system resource monitor
  - By default, the system monitor will include all the `dev.galasa.*`resource management services available in the OBR (dev.galasa.uber.obr) that is bundled within the boot image.