### PR TITLE
Add kubeLaunchIntervalMillisecs value to configure the interval between launching test pods

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -47,7 +47,8 @@ data:
   # The amount of CPU each test pod is allowed to consume were it to be available. Integer. Units of 'm' A value of 0 means we don't set the limit.
   engine_cpu_limit: "{{- .Values.testPod.cpu.max | default 1000 -}}"
 
-
+  # The amount of time in milliseconds to wait before the test pod scheduler launches another test pod
+  kube_launch_interval_milliseconds: "{{ .Values.kubeLaunchIntervalMillisecs | default 1000 }}"
   run_poll: "5"
   run_poll_recheck: "2"
 #

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -43,6 +43,11 @@ galasaBootImage: "galasa-boot-embedded-amd64"
 maxEngines: "10"
 #
 #
+# The number of milliseconds that the test pod scheduler should delay between successive launches of test pods
+#
+kubeLaunchIntervalMillisecs: 1000
+#
+#
 # The name of the Docker image that launches Galasa's web UI
 #
 galasaWebUiImage: "galasa-ui"


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2236

## Changes
- Added `kube_launch_interval_milliseconds` setting to the engine controller settings ConfigMap
- Added a corresponding `kubeLaunchIntervalMillisecs` value to the values.yaml file, defaults to 1000ms