### PR TITLE
Make engine controller, metrics, and resource monitor pods wait for store pods before starting up to avoid errors

### DIFF
--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -29,6 +29,40 @@ spec:
         {{- if .Values.nodeSelectors }}
 {{ toYaml .Values.nodeSelectors | indent 8 }}
         {{- end }}
+      initContainers:
+      - name: wait-for-etcd
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-etcd
+          - --for=condition=Ready
+          - --timeout=90s
+      - name: wait-for-ras
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-ras
+          - --for=condition=Ready
+          - --timeout=90s
+      - name: wait-for-dex
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-dex
+          - --for=condition=Ready
+          - --timeout=90s
       containers:
       - name: engine-controller
         image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -29,6 +29,40 @@ spec:
         {{- if .Values.nodeSelectors }}
 {{ toYaml .Values.nodeSelectors | indent 8 }}
         {{- end }}
+      initContainers:
+      - name: wait-for-etcd
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-etcd
+          - --for=condition=Ready
+          - --timeout=90s
+      - name: wait-for-ras
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-ras
+          - --for=condition=Ready
+          - --timeout=90s
+      - name: wait-for-dex
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-dex
+          - --for=condition=Ready
+          - --timeout=90s
       containers:
       - name: metrics
         image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -30,6 +30,40 @@ spec:
         {{- if .Values.nodeSelectors }}
 {{ toYaml .Values.nodeSelectors | indent 8 }}
         {{- end }}
+      initContainers:
+      - name: wait-for-etcd
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-etcd
+          - --for=condition=Ready
+          - --timeout=90s
+      - name: wait-for-ras
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-ras
+          - --for=condition=Ready
+          - --timeout=90s
+      - name: wait-for-dex
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-dex
+          - --for=condition=Ready
+          - --timeout=90s
       containers:
       - name: resource-monitor
         image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/helm/pull/77

Regardless of whether the couchdb, etcd, and dex pods are up, the engine controller, metrics, and resource monitor pods will attempt to start, which can cause them to run into errors. This PR adds init containers to wait for the pods used as Galasa stores to the services that use them (similar to the existing init containers that the API server uses), which will prevent pods from crashing out.