### PR TITLE
adding a pod maxPodRetryLimit  to the helm charts so pod re-spawning can't go beyond that

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -45,7 +45,16 @@ data:
 
   # The amount of time in milliseconds to wait before the test pod scheduler launches another test pod
   kube_launch_interval_milliseconds: "{{ .Values.kubeLaunchIntervalMillisecs | default 1000 }}"
+  
+  # Maximum number a run will re-try to create a test pod.
+  max_test_pod_retry_limit: "{{- .Values.enginecontroller:.maxTestPodRetryLimit | default 5 -}}"
+
+  # The time between scheduling a bunch of queued tests in fresh test pods, and when we look again for more test pods to queue.
+  # Unit is seconds. Defaults to 60 seconds if not set.
   run_poll: "5"
+
+  # >> Not used. Please ignore. <<
+  # Was used in the docker controller to space out requests to launch new docker pods. Unit is seconds.
   run_poll_recheck: "2"
 #
 # Label of k8s node that Galasa test pods should be scheduled on preferrentially
@@ -53,7 +62,6 @@ data:
 #
 # List of node toleration conditions
   galasa_node_tolerations: "{{ .Values.k8sNodeTolerations }}"
-
 
 #
 # The name of the Kubernetes Secret that stores the encryption-related keys,

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -461,6 +461,9 @@ webui:
 # The engine controller receives requests to start tests, and starts pods in which
 # the tests run.
 enginecontroller:
+  # Maximum number a run will re-try to create a test pod.
+  maxTestPodRetryLimit: 5
+
   # Best practice is to set memory limits for each pod.
   # This section sets some limits which Dex should be happy working within.
   # Omitting this resources: section will cause no memory or cpi limits to be set.
@@ -506,7 +509,7 @@ metrics:
 testPod:
   memory:
     # All values are integers, in units of 'Mi'
-    heap: 350
+    heap: 750
     min: 400
     max: 800
   cpu:


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

Issue: https://github.com/galasa-dev/projectmanagement/issues/2263

Added maxPodRetryLimit to the helm values.
Defaults to 5, meaning there can be at most 5 re-starts of the same test run.
