### PR TITLE
Pass GALASA_INSTALL_NAME to k8s controller so that it can query service pods

### DIFF
--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -83,6 +83,8 @@ spec:
             java -jar boot.jar --obr file:galasa.obr --setupeco
             java -jar boot.jar --obr file:galasa.obr --k8scontroller
         env:
+        - name: GALASA_INSTALL_NAME
+          value: {{ .Release.Name }}
         - name: NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Why?
Required for changes in https://github.com/galasa-dev/galasa/pull/347 for story https://github.com/galasa-dev/projectmanagement/issues/2235

## Changes
- Passed in the name provided in the Helm install command into the k8s controller deployment so that it can be used within the k8s controller code to query the status of other service pods, particularly the etcd and RAS pods