### PR TITLE
Iss2312 - Allow max gRPC message size to be set from Helm Chart value

### DIFF
--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -84,3 +84,10 @@
   {{- end }}
   {{- print $extraBundles }}
 {{- end -}}
+
+{{/*
+  Returns the maximum message size in bytes allowed for a single gRPC frame as an integer value.
+*/}}
+{{- define "max.grpc.message.size" -}}
+  {{- empty .Values.maxgRPCMessageSize | ternary (4194304) (.Values.maxgRPCMessageSize) }}
+{{- end -}}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -165,6 +165,8 @@ spec:
         - name: JDK_JAVA_OPTIONS
           value: -Djavax.net.ssl.trustStore=/galasa/certificates/cacerts
         {{- end }}
+        - name: MAX_GRPC_MESSAGE_SIZE
+          value: "{{ include "max.grpc.message.size" . }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/custom-resource-monitor.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor.yaml
@@ -87,6 +87,8 @@ spec:
         - name: JDK_JAVA_OPTIONS
           value: -Djavax.net.ssl.trustStore=/galasa/certificates/cacerts
         {{- end }}
+        - name: MAX_GRPC_MESSAGE_SIZE
+          value: "{{ include "max.grpc.message.size" . }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -130,6 +130,8 @@ spec:
         - name: JDK_JAVA_OPTIONS
           value: -Djavax.net.ssl.trustStore=/galasa/certificates/cacerts
         {{- end }}
+        - name: MAX_GRPC_MESSAGE_SIZE
+          value: "{{ include "max.grpc.message.size" . }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -107,6 +107,8 @@ spec:
         - name: JDK_JAVA_OPTIONS
           value: -Djavax.net.ssl.trustStore=/galasa/certificates/cacerts
         {{- end }}
+        - name: MAX_GRPC_MESSAGE_SIZE
+          value: "{{ include "max.grpc.message.size" . }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -118,6 +118,8 @@ spec:
         - name: JDK_JAVA_OPTIONS
           value: -Djavax.net.ssl.trustStore=/galasa/certificates/cacerts
         {{- end }}
+        - name: MAX_GRPC_MESSAGE_SIZE
+          value: "{{ include "max.grpc.message.size" . }}"
         ports:
         - containerPort: 9010
           name: metrics

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -607,6 +607,20 @@ resourceMonitor:
     limits:
       memory: "500Mi"
 #
+#
+#
+# Optional - The maximum message size in bytes allowed for a single gRPC frame.
+# This will be used by the KVClient that is set up to interact with the etcd3 cluster.
+# 
+# Defaults to 4194304 if not set.
+# 
+# The maximum value this can be set to is 2147483647.
+# There may be effects on performance when setting to larger than 10485760.
+#
+# Example value: 4194304
+#
+maxgRPCMessageSize: {}
+#
 # The global Log4j2 configuration properties applied to all Galasa service pods.
 # By default, a console appender with debug level logging is configured to send logs to stdout.
 #


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2312

Allow max gRPC message size to be set from Helm Chart value to avoid the error `RESOURCE_EXHAUSTED: gRPC message exceeds maximum size`.

## Changes

- New optional parameter added to the values.yaml file to set a new maximum message size for a gRPC frame.
- Helper template to default this value if not provided, and also transform into an integer.
- Pass this new parameter in as an environment variable to all deployments so it can be used when setting up a client to talk to etcd3 with.