### PR TITLE
Add test pod interrupt timeout value to engine controller config

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -50,7 +50,7 @@ data:
   max_test_pod_retry_limit: "{{ .Values.enginecontroller.maxTestPodRetryLimit | default 5 }}"
 
   # The amount of time in seconds the engine controller will wait before it deletes an interrupted run's test pod
-  test_pod_interrupt_timeout_secs: "{{ .Values.enginecontroller.testPodInterruptTimeoutSecs | default 300 }}"
+  interrupted_test_run_cleanup_grace_period_seconds: "{{ .Values.enginecontroller.interruptedTestRunCleanupGracePeriodSecs | default 300 }}"
 
   # The time between scheduling a bunch of queued tests in fresh test pods, and when we look again for more test pods to queue.
   # Unit is seconds. Defaults to 60 seconds if not set.

--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -49,6 +49,9 @@ data:
   # Maximum number a run will re-try to create a test pod.
   max_test_pod_retry_limit: "{{ .Values.enginecontroller.maxTestPodRetryLimit | default 5 }}"
 
+  # The amount of time in seconds the engine controller will wait before it deletes an interrupted run's test pod
+  test_pod_interrupt_timeout_secs: "{{ .Values.enginecontroller.testPodInterruptTimeoutSecs | default 300 }}"
+
   # The time between scheduling a bunch of queued tests in fresh test pods, and when we look again for more test pods to queue.
   # Unit is seconds. Defaults to 60 seconds if not set.
   run_poll: "5"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -464,6 +464,10 @@ enginecontroller:
   # Maximum number a run will re-try to create a test pod.
   maxTestPodRetryLimit: 5
 
+  # The amount of time in seconds the engine controller will wait before
+  # an interrupted run's test pod is deleted from the Kubernetes namespace
+  testPodInterruptTimeoutSecs: 300
+
   # Best practice is to set memory limits for each pod.
   # This section sets some limits which Dex should be happy working within.
   # Omitting this resources: section will cause no memory or cpi limits to be set.

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -466,7 +466,7 @@ enginecontroller:
 
   # The amount of time in seconds the engine controller will wait before
   # an interrupted run's test pod is deleted from the Kubernetes namespace
-  testPodInterruptTimeoutSecs: 300
+  interruptedTestRunCleanupGracePeriodSecs: 300
 
   # Best practice is to set memory limits for each pod.
   # This section sets some limits which Dex should be happy working within.


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2317
Related to changes in https://github.com/galasa-dev/galasa/pull/376

## Changes
- Added a `interruptedTestRunCleanupGracePeriodSecs` value to allow admins to configure the amount of time (in seconds) the engine controller waits before deleting an interrupted run's test pod and updating the run's DSS properties and RAS record
  - This value defaults to 5 minutes (300 seconds)