### PR TITLE
Add a Job that creates the _users db in CouchDB, stop resources from being deleted on upgrades

### DIFF
--- a/charts/ecosystem/templates/couchdb-setup-job.yaml
+++ b/charts/ecosystem/templates/couchdb-setup-job.yaml
@@ -36,13 +36,20 @@ spec:
           - --timeout=90s
       containers:
       - name: create-couchdb-users-database
-        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
+        image: {{ .Values.couchdbImage }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command:
           - /bin/bash
           - -ec
           - |
-            curl --silent --show-error -X PUT -H "Authorization: Basic ${GALASA_RAS_TOKEN}" http://{{ .Release.Name }}-couchdb:5984/_users
+            auth_header="Authorization: Basic ${GALASA_RAS_TOKEN}"
+            db_exists_code=$(curl --silent --output /dev/null -w "%{http_code}" --head -H "${auth_header}" http://{{ .Release.Name }}-couchdb:5984/_users)
+
+            if [[ ${db_exists_code} == "404" ]]; then
+              curl --silent --show-error -X PUT -H "${auth_header}" http://{{ .Release.Name }}-couchdb:5984/_users
+            else
+              echo "Users database already exists - OK"
+            fi
         env:
         - name: GALASA_RAS_TOKEN
           valueFrom:

--- a/charts/ecosystem/templates/couchdb-setup-job.yaml
+++ b/charts/ecosystem/templates/couchdb-setup-job.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-couchdb-setup"
+spec:
+  ttlSecondsAfterFinished: 120
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-couchdb-setup"
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: {{ .Values.architecture }}
+        {{- if .Values.nodeSelectors }}
+{{ toYaml .Values.nodeSelectors | indent 8 }}
+        {{- end }}
+      restartPolicy: Never
+      serviceAccountName: galasa
+      initContainers:
+      - name: wait-for-ras
+        image: {{ .Values.kubectlImage }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - kubectl
+        args:
+          - wait
+          - pods
+          - -l=app={{ .Release.Name }}-ras
+          - --for=condition=Ready
+          - --timeout=90s
+      containers:
+      - name: create-couchdb-users-database
+        image: {{ .Values.galasaRegistry }}/{{ .Values.galasaBootImage }}:{{ .Values.galasaVersion }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command:
+          - /bin/bash
+          - -ec
+          - |
+            curl --silent --show-error -X PUT -H "Authorization: Basic ${GALASA_RAS_TOKEN}" http://{{ .Release.Name }}-couchdb:5984/_users
+        env:
+        - name: GALASA_RAS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-couchdb-secret
+              key: GALASA_RAS_TOKEN

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -23,8 +23,6 @@ type: Opaque
 stringData:
   GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
 
-{{- end -}}
-
 # eventStreamsSecretName not set in values.yaml so generate a name and a Secret
 {{- else }}
 
@@ -39,5 +37,5 @@ metadata:
 type: Opaque
 stringData:
   GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
-
+{{- end }}
 {{- end }}

--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -3,12 +3,23 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+# Creates the "galasa" ServiceAccount and associated Role and RoleBinding if the ServiceAccount doesn't already exist,
+# or if the ServiceAccount was set up by Helm.
+#
+# When a "helm upgrade" is issued, Helm applies any changes to the YAML templates. Having the additional check to make
+# sure that the ServiceAccount was created by Helm means that this template will not be rendered as an empty template,
+# which would otherwise cause Helm to delete these resources.
+#
+{{- $serviceAccount := (lookup "v1" "ServiceAccount" .Release.Namespace "galasa") }}
+{{- $isServiceAccountOwnedByHelm := (and $serviceAccount (eq (index $serviceAccount.metadata.labels "app.kubernetes.io/instance") .Release.Name)) }}
 
-{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace "galasa") }}
+{{- if or (not $serviceAccount) $isServiceAccountOwnedByHelm }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: galasa
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 
 ---
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2234

## Changes
- Added a new couchdb-setup job that runs as part of the `helm install` and `helm upgrade` processes that waits for the RAS to be ready, checks if the `_users` database exists already (by sending a HEAD request to CouchDB) and if it doesn't exist, sends a PUT request to create the `_users` database
  - This job is automatically deleted after 2mins of its completion
- Fixed an issue where `helm upgrade` would cause the 'galasa' ServiceAccount and associated Role and RoleBinding to be deleted
- Fixed an issue with the event streams secret would get deleted when running `helm upgrade`