### PR TITLE
Check if the galasa service account has labels attached before attempting to check if Helm created it

### DIFF
--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -11,7 +11,11 @@
 # which would otherwise cause Helm to delete these resources.
 #
 {{- $serviceAccount := (lookup "v1" "ServiceAccount" .Release.Namespace "galasa") }}
-{{- $isServiceAccountOwnedByHelm := (and $serviceAccount (eq (index $serviceAccount.metadata.labels "app.kubernetes.io/instance") .Release.Name)) }}
+{{- $isServiceAccountOwnedByHelm := false }}
+
+{{- if (and $serviceAccount $serviceAccount.metadata.labels) }}
+{{- $isServiceAccountOwnedByHelm = (eq (index $serviceAccount.metadata.labels "app.kubernetes.io/instance") .Release.Name) }}
+{{- end }}
 
 {{- if or (not $serviceAccount) $isServiceAccountOwnedByHelm }}
 apiVersion: v1


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/helm/pull/87

## Changes
- Added a check to the 'galasa' ServiceAccount Helm template to check if the existing ServiceAccount has a `metadata.labels` object attached to it before proceeding to check if the ServiceAccount was created by Helm using a label attached to it