### PR TITLE
Stop evaluating all conditions at once in 'and' statement when deciding whether to create the 'galasa' ServiceAccount

### DIFF
--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -13,8 +13,12 @@
 {{- $serviceAccount := (lookup "v1" "ServiceAccount" .Release.Namespace "galasa") }}
 {{- $isServiceAccountOwnedByHelm := false }}
 
-{{- if (and $serviceAccount $serviceAccount.metadata.labels) }}
+{{- if $serviceAccount }}
+{{- if $serviceAccount.metadata }}
+{{- if $serviceAccount.metadata.labels }}
 {{- $isServiceAccountOwnedByHelm = (eq (index $serviceAccount.metadata.labels "app.kubernetes.io/instance") .Release.Name) }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- if or (not $serviceAccount) $isServiceAccountOwnedByHelm }}


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/helm/pull/88

prod1's ArgoCD app is seemingly evaluating both expressions in `if (and $serviceAccount $serviceAccount.metadata.labels)`, which is causing a nil exception to be thrown if the service account doesn't exist. This PR separates the conditions into separate `if` blocks