### PR TITLE
Create a Helm chart that handles the installation of issuers and certificates in a namespace using cert-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Galasa provides Helm charts to install various components, the main one being a 
       - [Linux](#linux)
       - [macOS](#macos)
     - [Development](#development)
+  - [Certificate Installer chart](./charts/cert-installer/README.md)
 
 ## Galasa Ecosystem chart
 ### Kubernetes RBAC setup

--- a/charts/cert-installer/Chart.yaml
+++ b/charts/cert-installer/Chart.yaml
@@ -1,0 +1,11 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v2
+name: cert-installer
+description: A chart that installs the resources needed to issue a TLS certificate using cert-manager
+type: application
+version: 0.0.1

--- a/charts/cert-installer/README.md
+++ b/charts/cert-installer/README.md
@@ -1,0 +1,134 @@
+# cert-installer Helm chart
+
+This is a Helm chart that installs the resources needed to issue a certificate for a service exposed via a Kubernetes Ingress using cert-manager.
+
+The chart assumes that you have [cert-manager](https://cert-manager.io) installed on your Kubernetes cluster.
+
+When installed, the following resources are created:
+- An `Issuer` resource, configured to use the ACME CA server
+- A `Certificate` resource representing the TLS certificate that was issued for your service
+
+## Installing the Helm chart
+
+Configure the Helm chart's values via a YAML file:
+
+1. Create a copy of the chart's [`values.yaml`](./values.yaml) file
+2. Add a host name into the `dnsNames` value for the host that you wish to issue a certificate for. For example:
+
+```yaml
+dnsNames:
+  - myservice.galasa.dev
+```
+
+2. Provide an email address for the `email` value, for example:
+
+```yaml
+email: user@example.com
+```
+
+Install the Helm chart:
+1. Run the following command:
+
+```
+helm upgrade --install --values /path/to/values.yaml <installation-name> /path/to/cert-installer --namespace <namespace>
+```
+
+where:
+- `/path/to/values.yaml` is the file path to the YAML file containing the values that were configured in the previous steps
+- `<installation-name>` is a name that should be associated with the Helm chart's installation
+- `/path/to/cert-installer` is the file path to the `cert-installer` directory on your machine
+- `<namespace>` is the Kubernetes namespace that you wish to install the Helm chart into
+
+2. Check that a certificate was issued by getting the status of the Certificate resource in Kubernetes with:
+
+```
+kubectl get certificates
+```
+
+This will produce the following output:
+
+```
+NAME                 READY   SECRET                      AGE
+myservice-tls-cert   False   myservice-tls-cert-secret   34s
+```
+
+For more information about the status of the certificate, you can run:
+```
+kubectl describe certificate <certificate-name>
+```
+where `<certificate-name>` is the name of the Certificate resource that was created. This will display a set of events, like:
+
+```
+Events:
+  Type    Reason     Age   From                                       Message
+  ----    ------     ----  ----                                       -------
+  Normal  Issuing    30s   cert-manager-certificates-trigger          Issuing certificate as Secret does not exist
+  Normal  Generated  30s   cert-manager-certificates-key-manager      Stored new private key in temporary Secret resource "myservice-tls-cert-hzrr2"
+  Normal  Requested  30s   cert-manager-certificates-request-manager  Created new CertificateRequest resource "myservice-tls-cert-1
+```
+
+After a short period of time, the certificate will be issued and its `READY` status should change from `False` to `True` when running `kubectl get certificate`. A new event should also appear when the certificate is issued when running `kubectl describe certificate <certificate-name>`:
+
+```
+Events:
+  Type    Reason     Age   From                                       Message
+  ----    ------     ----  ----                                       -------
+  ...
+  Normal  Issuing    6m22s  cert-manager-certificates-issuing          The certificate has been successfully issued
+```
+
+3. Now that a certificate has been successfully issued, update the `useIssuerProductionUrl` value in your values file from `false` to `true`, so it should look like:
+
+```yaml
+useIssuerProductionUrl: true
+```
+
+4. Run the following command to switch from using the ACME staging issuer to the production issuer:
+
+```
+helm upgrade --values /path/to/values.yaml <installation-name> /path/to/cert-installer --namespace <namespace>
+```
+
+where:
+- `/path/to/values.yaml` is the file path to the YAML file containing the values that were configured in the previous steps
+- `<installation-name>` is the name that was set when the Helm chart was installed
+- `/path/to/cert-installer` is the file path to the `cert-installer` directory on your machine
+- `<namespace>` is the Kubernetes namespace that the Helm chart was installed into
+
+5. Wait for the new certificate to be issued using the ACME CA production server, monitoring the status of the certificate by running `kubectl get certificates`
+
+You should now have a certificate that is ready to be used by your Ingress resources.
+
+## Using the Certificate in Ingresses
+
+Once you have an issued certificate, you can modify your Kubernetes Ingress definitions to use the certificate:
+
+1. Add a `tls` section into your Ingress YAML definition's `spec` field. For example, if the DNS name that you issued a certificate for is `myservice.galasa.dev` and the cert-installer's Helm installation name that you provided was `myservice`, then the Ingress would look like:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tls-example-ingress
+spec:
+  # --------------------------------------------------
+  # Add a TLS section like this into your Ingress YAML
+  tls:
+  - hosts:
+      - myservice.galasa.dev
+    secretName: myservice-secret
+  # --------------------------------------------------
+  rules:
+  - host: myservice.galasa.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80
+```
+
+2. Apply the changes to your Ingress resource (if using Helm, you can run a `helm upgrade` command) and then the service should be using the new certificate

--- a/charts/cert-installer/templates/certificate.yaml
+++ b/charts/cert-installer/templates/certificate.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-cert
+spec:
+  secretName: {{ .Release.Name }}-secret
+  dnsNames:
+    {{- with .Values.dnsNames }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  issuerRef:
+    kind: Issuer
+  {{- if .Values.useIssuerProductionUrl }}
+    name: {{ .Release.Name }}-letsencrypt-prod
+  {{- else }}
+    name: {{ .Release.Name }}-letsencrypt-staging
+  {{- end }}

--- a/charts/cert-installer/templates/prod-issuer.yaml
+++ b/charts/cert-installer/templates/prod-issuer.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This is a namespaced Issuer resource that requests certificates to be issued from the Let's Encrypt
+# production issuer. The production issuer has very strict rate limits, so to avoid hitting
+# them when experimenting with changes, use the letsencrypt-staging issuer instead.
+# 
+{{- if .Values.useIssuerProductionUrl }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+  {{- if .Values.email }}
+    # The email that Let's Encrypt will use to contact you about expiring
+    # certificates, and issues related to your account
+    email: {{ .Values.email }}
+  {{- end }}
+    # The ACME certificate profile
+    profile: tlsserver
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: {{ .Release.Name }}-letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: {{ .Values.ingressClassName }}
+{{- end }}

--- a/charts/cert-installer/templates/staging-issuer.yaml
+++ b/charts/cert-installer/templates/staging-issuer.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This is a namespaced Issuer resource that requests certificates to be issued from the Let's Encrypt
+# staging issuer. The staging issuer should be used for development and testing purposes only.
+# Use the letsencrypt-prod issuer for production use.
+# 
+{{- if not .Values.useIssuerProductionUrl }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+  {{- if .Values.email }}
+    # The email that Let's Encrypt will use to contact you about expiring
+    # certificates, and issues related to your account
+    email: {{ .Values.email }}
+  {{- end }}
+    # The ACME certificate profile
+    profile: tlsserver
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: {{ .Release.Name }}-letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: {{ .Values.ingressClassName }}
+{{- end }}

--- a/charts/cert-installer/values.yaml
+++ b/charts/cert-installer/values.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# A list of DNS names to issue a certificate for
+# For example, to issue a certificate for 'myservice.galasa.dev', the value would look like:
+#
+# dnsNames:
+#   - myservice.galasa.dev
+#
+dnsNames: []
+
+# The name of the ingress class that you are using for your exposed Ingress resources.
+# Different cloud providers may offer their own ingress classes. For example, IBM Cloud
+# offers 'public-iks-k8s-nginx' and 'private-iks-k8s-nginx' classes.
+ingressClassName: nginx
+
+# Determines whether the Issuer resource should use a production URL to issue certificates.
+# When `useIssuerProductionUrl` is false, the ACME staging URL will be used (https://acme-staging-v02.api.letsencrypt.org/directory).
+# When `useIssuerProductionUrl` is true, the ACME production URL will be used (https://acme-v02.api.letsencrypt.org/directory).
+# This value should only be set to true once you have made sure that certificates can be issued successfully using the staging URL.
+useIssuerProductionUrl: false
+
+# Optional. The email that should receive messages from Let's Encrypt about expiring certificates
+# and any issues associated with your account.
+email: ""


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2367
Related to changes in https://github.com/galasa-dev/automation/pull/728

## Changes
- Added a new `cert-installer` Helm chart that installs an Issuer resource (configured to use ACME certificate authority) and a Certificate for the given DNS names
  - A boolean value controls whether the staging Issuer or the production Issuer should be used
