### PR TITLE
Stop ignoring eventStreamsSecretName value

### DIFF
--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -64,5 +64,9 @@
   Returns the extra bundles to load when starting the framework
 */}}
 {{- define "framework.extra.bundles" -}}
-  {{- print "dev.galasa.cps.etcd,dev.galasa.ras.couchdb,dev.galasa.events.kafka" }}
+  {{- if .Values.eventStreamsSecretName }}
+    {{- print "dev.galasa.cps.etcd,dev.galasa.ras.couchdb,dev.galasa.events.kafka" }}
+  {{- else }}
+    {{- print "dev.galasa.cps.etcd,dev.galasa.ras.couchdb" }}
+  {{- end }}
 {{- end -}}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -146,11 +146,13 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        {{- if .Values.eventStreamsSecretName }}
         - name: GALASA_EVENT_STREAMS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: event-streams-token
+              name: "{{ .Values.eventStreamsSecretName }}"
               key: GALASA_EVENT_STREAMS_TOKEN
+        {{- end }}
         - name: GALASA_ENCRYPTION_KEYS_PATH
           value: {{ include "ecosystem.encryption.keys.path" . }}
         ports:

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -113,11 +113,13 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-couchdb-secret
               key: GALASA_RAS_TOKEN
+        {{- if .Values.eventStreamsSecretName }}
         - name: GALASA_EVENT_STREAMS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: event-streams-token
+              name: "{{ .Values.eventStreamsSecretName }}"
               key: GALASA_EVENT_STREAMS_TOKEN
+        {{- end }}
         - name: GALASA_ENCRYPTION_KEYS_PATH
           value: {{ include "ecosystem.encryption.keys.path" . }}
         ports:

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -6,36 +6,18 @@
 # eventStreamsSecretName set in values.yaml so use that Secret name for the lookup
 {{- if .Values.eventStreamsSecretName }}
 
+{{- $token := randAlphaNum 44 }}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace .Values.eventStreamsSecretName) }}
-
-# The Secret name was set in values but the Secret does not exist
-{{- if not $existingSecret }}
-
-# The Secret must be called this to match the API/Engine Controller deployment spec
-{{- $eventStreamsSecretName := "event-streams-token" }}
-{{- $token := randAlphaNum 44 }}
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $eventStreamsSecretName }}
-type: Opaque
-stringData:
-  GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
-
-# eventStreamsSecretName not set in values.yaml so generate a name and a Secret
-{{- else }}
-
-# The Secret must be called this to match the API/Engine Controller deployment spec
-{{- $eventStreamsSecretName := "event-streams-token" }}
-{{- $token := randAlphaNum 44 }}
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $eventStreamsSecretName }}
-type: Opaque
-stringData:
-  GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
+{{- if $existingSecret }}
+{{- $token = printf (index $existingSecret.data "GALASA_EVENT_STREAMS_TOKEN") | b64dec }}
 {{- end }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.eventStreamsSecretName }}
+type: Opaque
+stringData:
+  GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"
+
 {{- end }}

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -8,6 +8,8 @@
 
 {{- $token := randAlphaNum 44 }}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace .Values.eventStreamsSecretName) }}
+
+# If a secret already exists, use the secret's existing token value
 {{- if $existingSecret }}
 {{- $token = printf (index $existingSecret.data "GALASA_EVENT_STREAMS_TOKEN") | b64dec }}
 {{- end }}

--- a/charts/ecosystem/templates/event-streams-secret.yaml
+++ b/charts/ecosystem/templates/event-streams-secret.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.eventStreamsSecretName }}
+  name: {{ (printf "%s-%s" .Release.Name .Values.eventStreamsSecretName) }}
 type: Opaque
 stringData:
   GALASA_EVENT_STREAMS_TOKEN: "{{ $token }}"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -363,12 +363,15 @@ dex:
       memory: "500Mi"
 
 #
-# The name of the Kubernetes Secret that Galasa will look for in your Galasa service's
+# Optional. The name of the Kubernetes Secret that Galasa will look for in your Galasa service's
 # namespace to authenticate to a configured Kafka cluster, if you optionally wish to
 # publish events from Galasa to a Kafka cluster. When this chart is installed, it
 # will check for the existence of the Secret, and if it exists, will provide the
 # token as an environment variable to Pods that need to authenticate to a Kafka cluster.
 # If the Secret doesn't exist, one will be generated.
+#
+# If no value is provided, then the Galasa service will not load its Kafka extension
+# to publish events to a Kafka cluster.
 #
 eventStreamsSecretName: "event-streams-token"
 #


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2390

## Changes
- The `eventStreamsSecretName` value is no longer ignored
- When the value is not set, then the dev.galasa.events.kafka extra bundle will no longer be loaded
