### PR TITLE
Add value to configure the timeout for runs in the 'allocated' state

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -52,6 +52,9 @@ data:
   # The amount of time in seconds the engine controller will wait before it deletes an interrupted run's test pod
   interrupted_test_run_cleanup_grace_period_seconds: "{{ .Values.enginecontroller.interruptedTestRunCleanupGracePeriodSecs | default 300 }}"
 
+  # The amount of time in minutes that test runs will be allowed to remain in the 'allocated' state before being cleaned up
+  allocated_test_run_timeout_minutes: "{{ .Values.enginecontroller.allocatedTestRunTimeoutMinutes | default 30 }}"
+
   # The time between scheduling a bunch of queued tests in fresh test pods, and when we look again for more test pods to queue.
   # Unit is seconds. Defaults to 60 seconds if not set.
   run_poll: "5"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -470,6 +470,10 @@ enginecontroller:
   # an interrupted run's test pod is deleted from the Kubernetes namespace
   interruptedTestRunCleanupGracePeriodSecs: 300
 
+  # The amount of time in minutes that test runs will be allowed to remain in
+  # the 'allocated' state before being automatically interrupted and cleaned up.
+  allocatedTestRunTimeoutMinutes: 30
+
   # Best practice is to set memory limits for each pod.
   # This section sets some limits which Dex should be happy working within.
   # Omitting this resources: section will cause no memory or cpi limits to be set.


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2269
Directly related to changes in https://github.com/galasa-dev/galasa/pull/410

## Changes
- Added a `allocatedTestRunTimeoutMinutes` value that is passed into the `allocated_test_run_timeout_minutes` setting in the ConfigMap used by the engine controller to determine the amount of time in minutes that a test run can remain in the `allocated` state before being interrupted