### PR TITLE
Add value to provide a custom logj4 config to Galasa service pods

### DIFF
--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -105,6 +105,8 @@ spec:
         - --api
         - --bootstrap
         - file:/bootstrap.properties
+        - --log4j2-properties-file
+        - file:/log4j2.properties
         env:
         # The Kubernetes namespace that the Galasa service is running within is passed into the API server
         # so that the API server can query Kubernetes for monitor deployments in the /monitors REST APIs
@@ -178,6 +180,10 @@ spec:
         - name: bootstrap
           mountPath: /bootstrap.properties
           subPath: bootstrap.properties
+        - name: log4j2-config
+          mountPath: /log4j2.properties
+          subPath: log4j2.properties
+          readOnly: true
         - name: testcatalog
           mountPath: /galasa/load/dev.galasa.testcatalog.cfg
           subPath: dev.galasa.testcatalog.cfg
@@ -190,6 +196,9 @@ spec:
       - name: bootstrap
         configMap:
           name: {{ .Release.Name }}-bootstrap-file
+      - name: log4j2-config
+        configMap:
+          name: {{ .Release.Name }}-log4j2-config
       - name: testcatalog
         configMap:
           name: {{ .Release.Name }}-testcatalog-file

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -80,8 +80,8 @@ spec:
           - /bin/bash
           - -ec
           - |
-            java -jar boot.jar --obr file:galasa.obr --setupeco
-            java -jar boot.jar --obr file:galasa.obr --k8scontroller
+            java -jar boot.jar --obr file:galasa.obr --setupeco --log4j2-properties-file file:/log4j2.properties
+            java -jar boot.jar --obr file:galasa.obr --k8scontroller --log4j2-properties-file file:/log4j2.properties
         env:
         - name: GALASA_INSTALL_NAME
           value: {{ .Release.Name }}
@@ -143,7 +143,14 @@ spec:
         - name: encryption-keys
           mountPath: {{ include "ecosystem.encryption.keys.directory" . }}
           readOnly: true
+        - name: log4j2-config
+          mountPath: /log4j2.properties
+          subPath: log4j2.properties
+          readOnly: true
       volumes:
       - name: encryption-keys
         secret:
           secretName: {{ include "ecosystem.encryption.keys.secret.name" . }}
+      - name: log4j2-config
+        configMap:
+          name: {{ .Release.Name }}-log4j2-config

--- a/charts/ecosystem/templates/log4j2-config.yaml
+++ b/charts/ecosystem/templates/log4j2-config.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# A ConfigMap that contains the global Log4j2 configuration that will be applied to all Galasa service pods
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-log4j2-config
+data:
+  log4j2.properties: {{ .Values.log4j2Properties | quote }}

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -83,7 +83,8 @@ spec:
         - --obr
         - file:galasa.obr
         - --metricserver
-        - --trace
+        - --log4j2-properties-file
+        - file:/log4j2.properties
         env:
         - name: GALASA_EXTRA_BUNDLES
           value: {{ include "framework.extra.bundles" . }}
@@ -117,3 +118,12 @@ spec:
             port: 9010
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        - name: log4j2-config
+          mountPath: /log4j2.properties
+          subPath: log4j2.properties
+          readOnly: true
+      volumes:
+      - name: log4j2-config
+        configMap:
+          name: {{ .Release.Name }}-log4j2-config

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -84,6 +84,8 @@ spec:
         - --obr
         - file:galasa.obr
         - --resourcemanagement
+        - --log4j2-properties-file
+        - file:/log4j2.properties
         env:
         - name: NAMESPACE
           valueFrom:
@@ -125,3 +127,12 @@ spec:
             port: 9011
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        - name: log4j2-config
+          mountPath: /log4j2.properties
+          subPath: log4j2.properties
+          readOnly: true
+      volumes:
+      - name: log4j2-config
+        configMap:
+          name: {{ .Release.Name }}-log4j2-config

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -572,3 +572,41 @@ resourceMonitor:
       memory: "300Mi"
     limits:
       memory: "500Mi"
+#
+# The global Log4j2 configuration properties applied to all Galasa service pods.
+# By default, a console appender with debug level logging is configured to send logs to stdout.
+#
+# This value is expected to be supplied properties as a string in the form:
+#
+# log4j2Properties: |
+#   status = error
+#   name = Default
+#
+#   appender.console.type = Console
+#   appender.console.name = stdout
+#   appender.console.layout.type = PatternLayout
+#   appender.console.layout.pattern = %d{dd/MM/yyyy HH:mm:ss.SSS} %-5p %c{1.} - %m%n
+#
+#   rootLogger.level = debug
+#   rootLogger.appenderRef.stdout.ref = stdout
+#
+log4j2Properties: |
+  status = error
+  name = Default
+
+  appender.console.type = Console
+  appender.console.name = stdout
+  appender.console.layout.type = PatternLayout
+  appender.console.layout.pattern = %d{dd/MM/yyyy HH:mm:ss.SSS} %-5p %c{1.} - %m%n
+
+  rootLogger.level = debug
+  rootLogger.appenderRef.stdout.ref = stdout
+
+  logger.http.name = org.apache.http
+  logger.http.level = info
+
+  logger.sshtools.name = com.sshtools
+  logger.sshtools.level = warn
+
+  logger.ftp.name = ftp
+  logger.ftp.level = info


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2246

## Changes
- Added a new `log4j2Properties` value to allow users to provide their own custom log4j configuration for global use by all Galasa service pods except test pods (test pods store run logs in the RAS so their logs are not expected to be sent to a different logging system)
- Added a ConfigMap that stores the provided log4j2 properties which is then mounted on to the API, engine controller, resource monitor, and metrics pods