### PR TITLE
Remove default CPU limits to stop them overriding CPU values of 0

### DIFF
--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -39,9 +39,9 @@ data:
   engine_memory_limit: "{{- .Values.testPod.memory.max | default 800 -}}"
 
   # The amount of CPU each test pods should get as a minimum. Integer. Units of 'm'. A value of 0 means we don't set the minimum.
-  engine_cpu_request: "{{- .Values.testPod.cpu.min | default 600 -}}"
+  engine_cpu_request: "{{- .Values.testPod.cpu.min }}"
   # The amount of CPU each test pod is allowed to consume were it to be available. Integer. Units of 'm' A value of 0 means we don't set the limit.
-  engine_cpu_limit: "{{- .Values.testPod.cpu.max | default 1000 -}}"
+  engine_cpu_limit: "{{- .Values.testPod.cpu.max }}"
 
   # The amount of time in milliseconds to wait before the test pod scheduler launches another test pod
   kube_launch_interval_milliseconds: "{{ .Values.kubeLaunchIntervalMillisecs | default 1000 }}"


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2495

## Changes
- Remove default CPU min and max values in the engine controller config template to stop them from overriding the CPU limits when they are set to 0 (no limit)