### PR TITLE
Update development version to 0.48.0

### DIFF
--- a/charts/ecosystem/Chart.yaml
+++ b/charts/ecosystem/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 #
 home: "galasa.dev"
 #
-version: "0.47.0"
+version: "0.48.0"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -13,7 +13,7 @@ externalHostname: "example.com"
 # The version of Galasa you want to run with, it is better that you do not use "latest" to ensure
 # all the components are running the same version and a controlled upgrade can be performed
 #
-galasaVersion: "0.47.0"
+galasaVersion: "0.48.0"
 #
 #
 #


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2528. 

## Changes
- [x] Bumps the development version of Galasa to 0.48.0