### PR TITLE
Add values to configure the default RAS cleanup in the resource monitor

### DIFF
--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -116,6 +116,10 @@ spec:
           value: "{{ join "," .Values.resourceMonitor.includes }}"
         - name: GALASA_MONITOR_EXCLUDES_GLOB_PATTERNS
           value: "{{ join "," .Values.resourceMonitor.excludes }}"
+        - name: GALASA_TEST_RUN_CLEANUP_INTERVAL_HOURS
+          value: "{{ .Values.resourceMonitor.testRunCleanupIntervalHours }}"
+        - name: GALASA_TEST_RUN_CLEANUP_MAX_AGE_DAYS
+          value: "{{ .Values.resourceMonitor.testRunCleanupMaxAgeDays }}"
         {{- if .Values.certificatesConfigMapName }}
         - name: JDK_JAVA_OPTIONS
           value: -Djavax.net.ssl.trustStore=/galasa/certificates/cacerts

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -607,6 +607,15 @@ testPod:
 # see the 'cleanupMonitor' values.
 #
 resourceMonitor:
+  # The number of hours between each run of the test run cleanup monitor, which is used to
+  # clean up old test runs from the Result Archive Store.
+  # The default value is 24 hours. A value of 0 disables the cleanup of old test runs.
+  testRunCleanupIntervalHours: 24
+
+  # The maximum age of a test run in the Result Archive Store, in days.
+  # The default value is 30 days. A value of 0 disables the cleanup of old test runs.
+  testRunCleanupMaxAgeDays: 30
+
   #
   # A list of glob patterns to be used in identifying which resource cleanup providers to load.
   #


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2506. 

## Changes
- [x] Added `testRunCleanupIntervalHours` and `testRunCleanupMaxAgeDays` values to configure the main resource monitor pod's RAS cleanup process