### PR TITLE
Add support for Istio integration into the Galasa service Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,7 @@ To enable mTLS for internal pod-to-pod traffic:
 ```yaml
 istio:
   enabled: true
-  mtls:
-    mode: "STRICT"  # Recommended for production
+  mtlsMode: "STRICT"  # Recommended for production
 ```
 
 **External Traffic Routing:**
@@ -255,8 +254,7 @@ Istio can also handle external traffic routing. Choose one option:
 ```yaml
 istio:
   enabled: true
-  mtls:
-    mode: "STRICT"
+  mtlsMode: "STRICT"
 
 gatewayApi:
   enabled: true
@@ -284,8 +282,7 @@ Then configure the chart's values:
 ```yaml
 istio:
   enabled: true
-  mtls:
-    mode: "STRICT"
+  mtlsMode: "STRICT"
 
 ingress:
   enabled: true
@@ -298,7 +295,7 @@ ingress:
 **Configuration Options:**
 
 - `istio.enabled`: Enable or disable Istio integration (default: `false`)
-- `istio.mtls.mode`: mTLS enforcement mode
+- `istio.mtlsMode`: mTLS enforcement mode
   - `STRICT`: Only mTLS traffic allowed (recommended for production)
   - `PERMISSIVE`: Both mTLS and plaintext allowed (useful for migration)
   - `DISABLE`: mTLS disabled
@@ -319,8 +316,7 @@ For existing deployments, use a gradual migration approach:
    ```yaml
    istio:
      enabled: true
-     mtls:
-       mode: "PERMISSIVE"
+     mtlsMode: "PERMISSIVE"
    ```
 
 2. **Upgrade your deployment:**
@@ -341,8 +337,7 @@ For existing deployments, use a gradual migration approach:
    ```yaml
    istio:
      enabled: true
-     mtls:
-       mode: "STRICT"
+     mtlsMode: "STRICT"
    ```
 
 5. **Upgrade again:**

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Your Galasa Ecosystem is now accessible at `https://galasa.example.com/api/boots
       - [GitHub Example](#github-example)
       - [Other Identity Providers](#other-identity-providers)
     - [Optional Configurations](#optional-configurations)
+      - [Istio Service Mesh](#istio-service-mesh)
       - [Storage Class](#storage-class)
       - [Kafka Integration](#kafka-integration)
       - [Custom Logging (Log4j2)](#custom-logging-log4j2)
@@ -225,6 +226,135 @@ Galasa uses [Dex](https://dexidp.io) for authentication. Configure a connector t
 Dex supports many connectors including Microsoft, LDAP, OIDC, and more. See the [Dex connectors documentation](https://dexidp.io/docs/connectors) for configuration examples.
 
 ### Optional Configurations
+
+#### Istio Service Mesh
+
+Galasa supports integration with [Istio](https://istio.io) service mesh to automatically encrypt all pod-to-pod traffic using mutual TLS (mTLS).
+
+**Prerequisites:**
+- Istio 1.29+ installed in your Kubernetes cluster
+- See [Istio installation guide](https://istio.io/latest/docs/setup/getting-started/)
+
+**Basic Configuration (Internal Traffic Only):**
+
+To enable mTLS for internal pod-to-pod traffic:
+
+```yaml
+istio:
+  enabled: true
+  mtls:
+    mode: "STRICT"  # Recommended for production
+```
+
+**External Traffic Routing:**
+
+Istio can also handle external traffic routing. Choose one option:
+
+**Option 1: Istio with Kubernetes Gateway API (Recommended)**
+
+```yaml
+istio:
+  enabled: true
+  mtls:
+    mode: "STRICT"
+
+gatewayApi:
+  enabled: true
+  gatewayClassName: "istio"  # Use Istio's Gateway implementation
+
+```
+
+**Option 2: Istio with Kubernetes Ingress**
+
+First, create an Istio IngressClass:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: istio
+spec:
+  controller: istio.io/ingress-controller
+EOF
+```
+
+Then configure the chart's values:
+
+```yaml
+istio:
+  enabled: true
+  mtls:
+    mode: "STRICT"
+
+ingress:
+  enabled: true
+  ingressClassName: "istio"  # Use Istio's Ingress controller
+
+```
+
+**Note:** When using Istio for external traffic, Istio handles both external ingress and internal mTLS encryption.
+
+**Configuration Options:**
+
+- `istio.enabled`: Enable or disable Istio integration (default: `false`)
+- `istio.mtls.mode`: mTLS enforcement mode
+  - `STRICT`: Only mTLS traffic allowed (recommended for production)
+  - `PERMISSIVE`: Both mTLS and plaintext allowed (useful for migration)
+  - `DISABLE`: mTLS disabled
+
+**How It Works:**
+
+When Istio is enabled:
+1. All Galasa service pods receive an Istio sidecar proxy
+2. The sidecar automatically encrypts all pod-to-pod traffic using mTLS
+3. Application code continues to use HTTP URLs - encryption is transparent
+4. Test pods launched by the Engine Controller also receive Istio sidecars
+
+**Migration Strategy:**
+
+For existing deployments, use a gradual migration approach:
+
+1. **Enable with PERMISSIVE mode:**
+   ```yaml
+   istio:
+     enabled: true
+     mtls:
+       mode: "PERMISSIVE"
+   ```
+
+2. **Upgrade your deployment:**
+   ```bash
+   helm upgrade my-galasa galasa/ecosystem -f values.yaml --wait
+   ```
+
+3. **Verify all services are working:**
+   ```bash
+   # Check that all pods have Istio sidecars (should show 2 containers per pod)
+   kubectl get pods
+   
+   # Verify mTLS is enabled by checking Istio proxy config
+   istioctl proxy-status 
+   ```
+
+4. **Switch to STRICT mode:**
+   ```yaml
+   istio:
+     enabled: true
+     mtls:
+       mode: "STRICT"
+   ```
+
+5. **Upgrade again:**
+   ```bash
+   helm upgrade my-galasa galasa/ecosystem -f values.yaml --wait
+   ```
+
+**Troubleshooting:**
+
+- **Pods not getting sidecars:** Verify Istio is installed with `kubectl get pods -n istio-system`
+- **Connection failures:** Use PERMISSIVE mode during migration, then switch to STRICT
+- **Check Istio proxy logs:** `kubectl logs <pod-name> -c istio-proxy`
 
 #### Storage Class
 

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -95,3 +95,10 @@
 {{- define "max.grpc.message.size" -}}
   {{- empty .Values.maxgRPCMessageSize | ternary (4194304) (.Values.maxgRPCMessageSize) }}
 {{- end -}}
+
+{{/*
+  Returns Istio mTLS mode
+*/}}
+{{- define "istio.mtls.mode" -}}
+  {{- .Values.istio.mtls.mode | default "STRICT" | upper }}
+{{- end -}}

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -100,5 +100,5 @@
   Returns Istio mTLS mode
 */}}
 {{- define "istio.mtls.mode" -}}
-  {{- .Values.istio.mtls.mode | default "STRICT" | upper }}
+  {{- .Values.istio.mtlsMode | default "STRICT" | upper }}
 {{- end -}}

--- a/charts/ecosystem/templates/api.yaml
+++ b/charts/ecosystem/templates/api.yaml
@@ -22,6 +22,9 @@ spec:
       name: {{ .Release.Name }}-api
       labels:
         app: {{ .Release.Name }}-api
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/charts/ecosystem/templates/config.yaml
+++ b/charts/ecosystem/templates/config.yaml
@@ -76,3 +76,6 @@ data:
 # The name of the Kubernetes Secret that stores the encryption-related keys,
 # so that test pods can decrypt credentials where necessary
   encryption_keys_secret_name: {{ include "ecosystem.encryption.keys.secret.name" . }}
+#
+# Istio sidecar injection for test pods
+  is_istio_enabled: "{{ .Values.istio.enabled }}"

--- a/charts/ecosystem/templates/couchdb-setup-job.yaml
+++ b/charts/ecosystem/templates/couchdb-setup-job.yaml
@@ -18,6 +18,10 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}-couchdb-setup"
+      {{- if .Values.istio.enabled }}
+      labels:
+        sidecar.istio.io/inject: "true"
+      {{- end }}
     spec:
       nodeSelector:
         kubernetes.io/arch: {{ .Values.architecture }}

--- a/charts/ecosystem/templates/couchdb.yaml
+++ b/charts/ecosystem/templates/couchdb.yaml
@@ -21,6 +21,9 @@ spec:
       name: {{ .Release.Name }}-ras
       labels:
         app: {{ .Release.Name }}-ras
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
     spec:
       nodeSelector:
         kubernetes.io/arch: {{ .Values.architecture }}

--- a/charts/ecosystem/templates/custom-resource-monitor.yaml
+++ b/charts/ecosystem/templates/custom-resource-monitor.yaml
@@ -22,6 +22,9 @@ spec:
       name: {{ .Release.Name }}-custom-resource-monitor
       labels:
         app: {{ .Release.Name }}-custom-resource-monitor
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/charts/ecosystem/templates/dex.yaml
+++ b/charts/ecosystem/templates/dex.yaml
@@ -19,6 +19,9 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-dex
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
     spec:
       serviceAccountName: galasa
       nodeSelector:

--- a/charts/ecosystem/templates/engine-controller.yaml
+++ b/charts/ecosystem/templates/engine-controller.yaml
@@ -22,6 +22,9 @@ spec:
       name: {{ .Release.Name }}-engine-controller
       labels:
         app: {{ .Release.Name }}-engine-controller
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/charts/ecosystem/templates/etcd.yaml
+++ b/charts/ecosystem/templates/etcd.yaml
@@ -35,6 +35,9 @@ spec:
       name: {{ .Release.Name }}-etcd
       labels:
         app: {{ .Release.Name }}-etcd
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         serviceName: {{ .Release.Name }}-etcd
     spec:

--- a/charts/ecosystem/templates/import-certificates-job.yaml
+++ b/charts/ecosystem/templates/import-certificates-job.yaml
@@ -18,6 +18,10 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}-import-certs"
+      {{- if .Values.istio.enabled }}
+      labels:
+        sidecar.istio.io/inject: "true"
+      {{- end }}
     spec:
       nodeSelector:
         kubernetes.io/arch: {{ .Values.architecture }}

--- a/charts/ecosystem/templates/istio/peer-authentication.yaml
+++ b/charts/ecosystem/templates/istio/peer-authentication.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+{{- if .Values.istio.enabled }}
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: {{ .Release.Name }}-mtls
+  namespace: {{ .Release.Namespace }}
+spec:
+  mtls:
+    mode: {{ include "istio.mtls.mode" . }}
+{{- end }}

--- a/charts/ecosystem/templates/metrics.yaml
+++ b/charts/ecosystem/templates/metrics.yaml
@@ -22,6 +22,9 @@ spec:
       name: {{ .Release.Name }}-metrics
       labels:
         app: {{ .Release.Name }}-metrics
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/charts/ecosystem/templates/resource-monitor.yaml
+++ b/charts/ecosystem/templates/resource-monitor.yaml
@@ -23,6 +23,9 @@ spec:
       name: {{ .Release.Name }}-resource-monitor
       labels:
         app: {{ .Release.Name }}-resource-monitor
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/charts/ecosystem/templates/webui.yaml
+++ b/charts/ecosystem/templates/webui.yaml
@@ -22,6 +22,9 @@ spec:
       name: {{ .Release.Name }}-webui
       labels:
         app: {{ .Release.Name }}-webui
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -737,15 +737,9 @@ istio:
   # that automatically encrypts traffic between services using mTLS.
   enabled: false
   
-  # mTLS (mutual TLS) configuration
-  mtls:
-    # The mTLS enforcement mode. Valid values:
-    # - "STRICT": Only mTLS traffic is allowed. Recommended for production.
-    # - "PERMISSIVE": Both mTLS and plaintext traffic are allowed. Useful for
-    #                 gradual migration from non-Istio to Istio deployments.
-    # - "DISABLE": mTLS is disabled (not recommended if Istio is enabled).
-    #
-    # For new deployments, use "STRICT".
-    # For existing deployments being migrated to Istio, start with "PERMISSIVE"
-    # and switch to "STRICT" after verifying all services work correctly.
-    mode: "STRICT"
+  # The mTLS enforcement mode. Valid values:
+  # - "STRICT": Only mTLS traffic is allowed. Recommended for production.
+  # - "PERMISSIVE": Both mTLS and plaintext traffic are allowed. Useful for
+  #                 gradual migration from non-Istio to Istio deployments.
+  # - "DISABLE": mTLS is disabled (not recommended if Istio is enabled).
+  mtlsMode: "STRICT"

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -723,3 +723,29 @@ log4jJsonTemplatesConfigMapName: ""
 # You can supply multiple '--from-file' flags if you would like to load the contents of multiple certificates
 # into the ConfigMap.
 certificatesConfigMapName: ""
+
+# Optional. Values to configure the use of Istio for Galasa services.
+# Istio provides automatic mutual TLS (mTLS) encryption for all pod-to-pod
+# communication within the cluster, enhancing security without requiring
+# application code changes.
+#
+# Istio must be installed in your Kubernetes cluster.
+#
+istio:
+  # Enable or disable Istio integration.
+  # When enabled, all Galasa service pods will receive an Istio sidecar proxy
+  # that automatically encrypts traffic between services using mTLS.
+  enabled: false
+  
+  # mTLS (mutual TLS) configuration
+  mtls:
+    # The mTLS enforcement mode. Valid values:
+    # - "STRICT": Only mTLS traffic is allowed. Recommended for production.
+    # - "PERMISSIVE": Both mTLS and plaintext traffic are allowed. Useful for
+    #                 gradual migration from non-Istio to Istio deployments.
+    # - "DISABLE": mTLS is disabled (not recommended if Istio is enabled).
+    #
+    # For new deployments, use "STRICT".
+    # For existing deployments being migrated to Istio, start with "PERMISSIVE"
+    # and switch to "STRICT" after verifying all services work correctly.
+    mode: "STRICT"


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/1531. 

## Changes
- [x] Added support for integrating Istio service mesh into the Galasa service Helm chart so that pod-to-pod communication within a Galasa service is secured by mTLS
- [x] Added docs on how to configure the Galasa service to use Istio and what's required in order to do so
- [x] When istio is enabled, all Galasa service pods will start with an istio proxy sidecar which automatically upgrades traffic to use mTLS. If a pod outside the service mesh attempts to talk to a Galasa service pod, the connection will be refused.
