### PR TITLE
Improve gateway API support in cert-installer chart and allow existing Gateway resources to be re-used in the ecosystem chart

### DIFF
--- a/charts/cert-installer/templates/prod-issuer.yaml
+++ b/charts/cert-installer/templates/prod-issuer.yaml
@@ -36,7 +36,7 @@ spec:
           gatewayHTTPRoute:
             parentRefs:
               - name: {{ .Values.gatewayName }}
-                namespace: {{ .Release.Namespace }}
+                namespace: {{ .Values.gatewayNamespace }}
                 kind: Gateway
         {{- end }}
 {{- end }}

--- a/charts/cert-installer/templates/prod-issuer.yaml
+++ b/charts/cert-installer/templates/prod-issuer.yaml
@@ -29,6 +29,14 @@ spec:
     # Enable the HTTP-01 challenge provider
     solvers:
       - http01:
+        {{- if .Values.ingressClassName }}
           ingress:
             ingressClassName: {{ .Values.ingressClassName }}
+        {{- else if .Values.gatewayName }}
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ .Values.gatewayName }}
+                namespace: {{ .Release.Namespace }}
+                kind: Gateway
+        {{- end }}
 {{- end }}

--- a/charts/cert-installer/templates/staging-issuer.yaml
+++ b/charts/cert-installer/templates/staging-issuer.yaml
@@ -29,6 +29,14 @@ spec:
     # Enable the HTTP-01 challenge provider
     solvers:
       - http01:
+        {{- if .Values.ingressClassName }}
           ingress:
             ingressClassName: {{ .Values.ingressClassName }}
+        {{- else if .Values.gatewayName }}
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ .Values.gatewayName }}
+                namespace: {{ .Values.gatewayNamespace }}
+                kind: Gateway
+        {{- end }}
 {{- end }}

--- a/charts/cert-installer/values.yaml
+++ b/charts/cert-installer/values.yaml
@@ -17,6 +17,12 @@ dnsNames: []
 # offers 'public-iks-k8s-nginx' and 'private-iks-k8s-nginx' classes.
 ingressClassName: nginx
 
+# The name of the Gateway resource that should have certificates issued for
+gatewayName: ""
+
+# The namespace of the Gateway resource provided in the "gatewayName" value
+gatewayNamespace: ""
+
 # Determines whether the Issuer resource should use a production URL to issue certificates.
 # When `useIssuerProductionUrl` is false, the ACME staging URL will be used (https://acme-staging-v02.api.letsencrypt.org/directory).
 # When `useIssuerProductionUrl` is true, the ACME production URL will be used (https://acme-v02.api.letsencrypt.org/directory).

--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -102,3 +102,17 @@
 {{- define "istio.mtls.mode" -}}
   {{- .Values.istio.mtlsMode | default "STRICT" | upper }}
 {{- end -}}
+
+{{/*
+  Returns the Gateway resource name
+*/}}
+{{- define "gateway.name" -}}
+  {{- .Values.gatewayApi.gatewayName | default "{{ .Release.Name }}-gateway" }}
+{{- end -}}
+
+{{/*
+  Returns the Gateway resource namespace
+*/}}
+{{- define "gateway.namespace" -}}
+  {{- .Values.gatewayApi.gatewayNamespace | default .Release.Namespace }}
+{{- end -}}

--- a/charts/ecosystem/templates/gateway-api/gateway.yaml
+++ b/charts/ecosystem/templates/gateway-api/gateway.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-{{- if and .Values.gatewayApi.enabled (not .Values.ingress.enabled) }}
+{{- if and (and .Values.gatewayApi.enabled (not .Values.ingress.enabled)) (not .Values.gatewayApi.gatewayName) }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -16,12 +16,11 @@ metadata:
 spec:
   gatewayClassName: {{ .Values.gatewayApi.gatewayClassName }}
   listeners:
-  {{- if eq (include "ecosystem.host.scheme" .) "http" }}
   - hostname: {{ .Values.externalHostname }}
     name: {{ .Release.Name }}-http
     port: 80
     protocol: HTTP
-  {{- else }}
+  {{- if eq (include "ecosystem.host.scheme" .) "https" }}
   - hostname: {{ .Values.externalHostname }}
     name: {{ .Release.Name }}-https
     port: 443

--- a/charts/ecosystem/templates/gateway-api/httproute.yaml
+++ b/charts/ecosystem/templates/gateway-api/httproute.yaml
@@ -17,7 +17,9 @@ spec:
   hostnames:
   - {{ .Values.externalHostname }}
   parentRefs:
-  - name: {{ .Release.Name}}-gateway
+  - name: {{ include "gateway.name" . }}
+    namespace: {{ include "gateway.namespace" . }}
+    kind: Gateway
   rules:
   - backendRefs:
     - name: {{ .Release.Name }}-api

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -280,11 +280,12 @@ gatewayApi:
   # A true/false value that determines whether to create Gateway API resources for accessing the Galasa service.
   enabled: false
 
-  # The name of an existing Gateway resource that you would like to re-use for this Galasa service
+  # Optional. The name of an existing Gateway resource that you would like to re-use for this Galasa service
   # If no value is provided, a new Gateway resource will be created in the namespace where the Helm chart is installed.
   gatewayName: ""
 
-  # The namespace where the existing Gateway resource referenced in the "gatewayName" value is located
+  # Optional. The namespace where the existing Gateway resource referenced in the `gatewayName` value is located.
+  # If no value is provided and the `gatewayName` value is not empty, the namespace where the Helm chart is installed will be used.
   gatewayNamespace: ""
 
   # The name of the GatewayClass to use for the Gateway API resources.

--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -280,6 +280,13 @@ gatewayApi:
   # A true/false value that determines whether to create Gateway API resources for accessing the Galasa service.
   enabled: false
 
+  # The name of an existing Gateway resource that you would like to re-use for this Galasa service
+  # If no value is provided, a new Gateway resource will be created in the namespace where the Helm chart is installed.
+  gatewayName: ""
+
+  # The namespace where the existing Gateway resource referenced in the "gatewayName" value is located
+  gatewayNamespace: ""
+
   # The name of the GatewayClass to use for the Gateway API resources.
   gatewayClassName: ""
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/1531. 

## Changes
- [x] Added values for gateway resources to the cert-installer chart so that cert-manager can use Gateways can be used instead of Ingress controllers
- [x] Added new `gatewayName` and `gatewayNamespace` values to allow users to re-use existing Gateway resources on their Kubernetes clusters with the Galasa service