### PR TITLE
Add istio sidecar to validation job used in the helm test command

### DIFF
--- a/charts/ecosystem/templates/validation.yaml
+++ b/charts/ecosystem/templates/validation.yaml
@@ -25,6 +25,9 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        {{- if .Values.istio.enabled }}
+        sidecar.istio.io/inject: "true"
+        {{- end }}
     spec:
       nodeSelector:
         kubernetes.io/arch: {{ .Values.architecture }}


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/1531.

## Changes
- [x] Added a missing sidecar injection to the validation job that is created when running `helm test <helm-release-name>` for the ecosystem chart
