### PR TITLE
Update helpers to correctly return default values when empty strings are provided

### DIFF
--- a/charts/ecosystem/templates/_helpers.tpl
+++ b/charts/ecosystem/templates/_helpers.tpl
@@ -100,19 +100,19 @@
   Returns Istio mTLS mode
 */}}
 {{- define "istio.mtls.mode" -}}
-  {{- .Values.istio.mtlsMode | default "STRICT" | upper }}
+  {{- empty .Values.istio.mtlsMode | ternary "STRICT" .Values.istio.mtlsMode | upper }}
 {{- end -}}
 
 {{/*
   Returns the Gateway resource name
 */}}
 {{- define "gateway.name" -}}
-  {{- .Values.gatewayApi.gatewayName | default "{{ .Release.Name }}-gateway" }}
+  {{- empty .Values.gatewayApi.gatewayName | ternary (printf "%s-gateway" .Release.Name) .Values.gatewayApi.gatewayName }}
 {{- end -}}
 
 {{/*
   Returns the Gateway resource namespace
 */}}
 {{- define "gateway.namespace" -}}
-  {{- .Values.gatewayApi.gatewayNamespace | default .Release.Namespace }}
+  {{- empty .Values.gatewayApi.gatewayNamespace | ternary .Release.Namespace .Values.gatewayApi.gatewayNamespace }}
 {{- end -}}


### PR DESCRIPTION
## Why?

Related to changes made for https://github.com/galasa-dev/projectmanagement/issues/1531 

## Changes
- [x] Fixed an issue where helm installs would fail if values for gatewayName and gatewayNamespace were kept as empty strings. The `default` function would only work if the values were missing altogether, which would never be the case as the values are always set to empty strings in the chart's values.yaml file by default
