### PR TITLE
fix: Add 'watch' for pods in the 'galasa' role's permissions

### DIFF
--- a/charts/ecosystem/rbac.yaml
+++ b/charts/ecosystem/rbac.yaml
@@ -27,7 +27,7 @@ rules:
   verbs: ["get","patch","list","watch","update"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get","list","create","delete"]
+  verbs: ["get","list","create","delete","watch"]
 
 ---
 

--- a/charts/ecosystem/templates/rbac.yaml
+++ b/charts/ecosystem/templates/rbac.yaml
@@ -64,7 +64,7 @@ rules:
   verbs: ["get","patch","list","watch","update"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get","list","create","delete"]
+  verbs: ["get","list","create","delete","watch"]
 
 ---
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2586

**Before:**
```
❯ k logs test-api-96c8d5879-fpr4m -c wait-for-ras
E0506 13:04:28.546094       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/tools/watch/informerwatcher.go:146: Failed to watch *unstructured.Unstructured: pods \"test-ras-0\" is forbidden: User \"system:serviceaccount:default:galasa\" cannot watch resource \"pods\" in API group \"\" in the namespace \"default\""
pod/test-ras-0 condition met
```

**After:**
```
❯ k logs test-api-d645bd66b-p4xkj -c wait-for-ras
pod/test-ras-0 condition met
```

## Changes
- [x] Added `watch` verb to the permissions list for `pods` in the `galasa` role, which resolves the errors being thrown in the init containers
