### PR TITLE
chore: Galasa Ecosystem Helm chart now pulls from new ICR namespace

### DIFF
--- a/charts/ecosystem/values.yaml
+++ b/charts/ecosystem/values.yaml
@@ -31,7 +31,7 @@ galasaServiceName: Galasa Service
 #
 # The container registry the Galasa images can be found in
 #
-galasaRegistry: "icr.io/galasadev"
+galasaRegistry: "icr.io/galasa"
 #
 #
 # The name of the Docker image that contains Galasa's boot.jar file to launch ecosystem services


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2490

## Changes
- [x] Updates the values.yaml for the ecosystem Helm chart to pull images from the new `icr.io/galasa` namespace starting from v1.0.
